### PR TITLE
Added several commands, added means to handle socket errors

### DIFF
--- a/STMicroelectronics/SPWF04Sx/FileEntity.cs
+++ b/STMicroelectronics/SPWF04Sx/FileEntity.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections;
+using System.Text;
+using System.Threading;
+
+namespace GHIElectronics.TinyCLR.Drivers.STMicroelectronics.SPWF04Sx
+{
+    public class FileEntity
+    {
+        public string Name { get; private set; }
+        public string Volume { get; private set; }
+        public string Length { get; private set; }
+
+        public FileEntity()
+        { }
+        public FileEntity(string volume, string length, string name)
+        {
+            this.Name = name;
+            this.Volume = volume;
+            this.Length = length;
+        }
+    }
+}

--- a/STMicroelectronics/SPWF04Sx/GHIElectronics.TinyCLR.Drivers.STMicroelectronics.SPWF04Sx.csproj
+++ b/STMicroelectronics/SPWF04Sx/GHIElectronics.TinyCLR.Drivers.STMicroelectronics.SPWF04Sx.csproj
@@ -34,13 +34,14 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="FileEntity.cs" />
     <Compile Include="Helpers.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SPWF04SxCommand.cs" />
     <Compile Include="SPWF04SxEnums.cs" />
     <Compile Include="SPWF04SxEvents.cs" />
     <Compile Include="SPWF04SxExceptions.cs" />
     <Compile Include="SPWF04SxInterface.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="GHIElectronics.TinyCLR.Drivers.STMicroelectronics.SPWF04Sx.nuspec" />

--- a/STMicroelectronics/SPWF04Sx/SPWF04SxEnums.cs
+++ b/STMicroelectronics/SPWF04Sx/SPWF04SxEnums.cs
@@ -45,6 +45,7 @@
         PWM = 0x18,
         TIME = 0x11,
         RANDOM = 0x12,
+        FSM = 0x21,
         FSU = 0x22,
         FSC = 0x23,
         FSD = 0x25,

--- a/STMicroelectronics/SPWF04Sx/SPWF04SxInterface.cs
+++ b/STMicroelectronics/SPWF04Sx/SPWF04SxInterface.cs
@@ -11,6 +11,8 @@ using GHIElectronics.TinyCLR.Devices.Gpio;
 using GHIElectronics.TinyCLR.Devices.Spi;
 using GHIElectronics.TinyCLR.Net.NetworkInterface;
 using GHIElectronics.TinyCLR.Drivers.STMicroelectronics.SPWF04Sx.Helpers;
+using System.Diagnostics;
+
 
 namespace GHIElectronics.TinyCLR.Drivers.STMicroelectronics.SPWF04Sx {
     public class SPWF04SxInterface : NetworkInterface, ISocketProvider, ISslStreamProvider, IDnsProvider, IDisposable {
@@ -33,6 +35,10 @@ namespace GHIElectronics.TinyCLR.Drivers.STMicroelectronics.SPWF04Sx {
         public SPWF04SxWiFiState State { get; private set; }
         public bool ForceSocketsTls { get; set; }
         public string ForceSocketsTlsCommonName { get; set; }
+
+        //Added by RoSchmi
+        private bool SocketErrorHappened = false;
+
 
         public static SpiConnectionSettings GetConnectionSettings(SpiChipSelectType chipSelectType, int chipSelectLine) => new SpiConnectionSettings {
             ClockFrequency = 8000000,
@@ -187,6 +193,428 @@ namespace GHIElectronics.TinyCLR.Drivers.STMicroelectronics.SPWF04Sx {
             return result.Substring(result.IndexOf(':') + 1);
         }
 
+        //*************************************** Added by RoSchmi  ***************************************************
+
+
+        /// <summary>
+        /// Computes a hash
+        /// 0:SHA1, 1:SHA224, 2:SHA256, 3:MD5
+        /// </summary>
+        /// <param name="function">The methode to use. 0:SHA1, 1:SHA224, 2:SHA256, 3:MD5</param>
+        /// <param name="filename">The name of the file that holds the data
+        public byte[] ComputeHash(string function, string filename)   // 0:SHA1, 1:SHA224, 2:SHA256, 3:MD5
+        {
+            var cmd = this.GetCommand()
+                .AddParameter(function)
+                .AddParameter(filename)
+                .Finalize(SPWF04SxCommandIds.HASH);
+            this.EnqueueCommand(cmd);
+            byte[] totalBuf = new byte[0];
+            byte[] lastBuf = new byte[0];
+            int offset = 0;
+            byte[] readBuf = new byte[50];
+            int len = readBuf.Length;
+            while (len > 0)
+            {
+                len = cmd.ReadBuffer(readBuf, 0, len);
+                lastBuf = totalBuf;
+                offset = lastBuf.Length;
+                totalBuf = new byte[offset + len];
+                Array.Copy(lastBuf, 0, totalBuf, 0, offset);
+                Array.Copy(readBuf, 0, totalBuf, offset, len);
+                readBuf = new byte[len];
+            }
+            this.FinishCommand(cmd);
+            return totalBuf;
+        }
+
+        public void Reset()
+        {
+            var cmd = this.GetCommand()
+               .Finalize(SPWF04SxCommandIds.RESET);
+            this.EnqueueCommand(cmd);
+            cmd.ReadBuffer();
+            this.FinishCommand(cmd);
+        }
+
+        public void SendAT()
+        {
+            var cmd = this.GetCommand()
+               .Finalize(SPWF04SxCommandIds.AT);
+            this.EnqueueCommand(cmd);
+            cmd.ReadBuffer();
+            this.FinishCommand(cmd);
+        }
+
+        /// <summary>
+        /// Mounts a memory volume
+        /// 0 = External Flash, 1 = User Flash, 2 = Ram, 3 = Application Flash
+        /// </summary>
+        /// /// <param name="volume">The volume to be mounted. 0 = External Flash, 1 = User Flash, 2 = Ram, 3 = Application Flash</param>
+        public void MountMemoryVolume(string volume)
+        {
+            if (!((volume == "0") || (volume == "1") || (volume == "2") || (volume == "3")))
+            { throw new NotSupportedException("Invalid volume. For volume only 0, 1, 2 or 3 are allowed"); }
+            var cmd = this.GetCommand()
+                .AddParameter(volume)
+                .Finalize(SPWF04SxCommandIds.FSM);
+            this.EnqueueCommand(cmd);
+            byte[] readBuf = new byte[50];
+            int len = cmd.ReadBuffer(readBuf, 0, 50);
+            this.FinishCommand(cmd);
+        }
+
+        /// <summary>
+        /// Sets the configuration of the SPWF04 module.
+        /// Make sure that only valid parameters are used.
+        /// No control mechanisms are implemented to control that things worked properly.
+        /// </summary>
+        public void SetConfiguration(string confParameter, string value)
+        {
+            var cmd = this.GetCommand()
+            .AddParameter(confParameter)
+            .AddParameter(value)
+            .Finalize(SPWF04SxCommandIds.SCFG);
+            this.EnqueueCommand(cmd);
+            byte[] readBuf = new byte[50];
+            int len = cmd.ReadBuffer(readBuf, 0, 50);
+            this.FinishCommand(cmd);
+        }
+
+        /// <summary>
+        /// Save the configuration of the SPWF04 module to the Flash.        
+        /// </summary>
+        public void SaveConfiguration()
+        {
+            var cmd = this.GetCommand()
+            .Finalize(SPWF04SxCommandIds.WCFG);
+            this.EnqueueCommand(cmd);
+            cmd.ReadBuffer();
+            this.FinishCommand(cmd);
+        }
+
+        /// <summary>
+        /// Get the configuration of the SPWF04 module.        
+        /// </summary>
+        /// <param name="configVariable">The configuration variable to retrieve. Leaving empty means all.</param>
+        public string GetConfiguration(string configVariable)
+        {
+            var cmd = this.GetCommand()
+             .AddParameter(configVariable)
+             .Finalize(SPWF04SxCommandIds.GCFG);
+            this.EnqueueCommand(cmd);
+            StringBuilder stringBuilder = new StringBuilder("");
+            byte[] readBuf = new byte[50];
+            int len = readBuf.Length;
+            while (len > 0)
+            {
+                len = cmd.ReadBuffer(readBuf, 0, len);
+                stringBuilder.Append(Encoding.UTF8.GetString(readBuf));
+                readBuf = new byte[len];
+            }
+            this.FinishCommand(cmd);
+            return stringBuilder.ToString();
+        }
+
+        /// <summary>
+        /// Gets time and date of SPWF04Sx module
+        /// </summary>
+        public string GetTime()
+        {
+            var cmd = this.GetCommand()
+               .Finalize(SPWF04SxCommandIds.TIME);
+            this.EnqueueCommand(cmd);
+            StringBuilder stringBuilder = new StringBuilder("");
+            byte[] readBuf = new byte[50];
+            int len = readBuf.Length;
+
+            while (len > 0)
+            {
+                len = cmd.ReadBuffer(readBuf, 0, len);
+                stringBuilder.Append(Encoding.UTF8.GetString(readBuf));
+                readBuf = new byte[len];
+            }
+            this.FinishCommand(cmd);
+
+            return stringBuilder.ToString();
+        }
+
+        /// <summary>
+        /// Gets the amount of free Ram and the list of files in the SPWF04Sx memory as a string
+        /// </summary>       
+        public string GetDiskContent()
+        {
+            var cmd = this.GetCommand()
+               .Finalize(SPWF04SxCommandIds.FSL);
+            this.EnqueueCommand(cmd);
+            StringBuilder stringBuilder = new StringBuilder("");
+            byte[] readBuf = new byte[50];
+            int len = readBuf.Length;
+            while (len > 0)
+            {
+                len = cmd.ReadBuffer(readBuf, 0, len);
+                stringBuilder.Append(Encoding.UTF8.GetString(readBuf));
+                readBuf = new byte[len];
+            }
+            this.FinishCommand(cmd);
+            return stringBuilder.ToString();
+        }
+
+        /// <summary>
+        /// Returns the properties 'Length', 'Volume' and 'Name' of the specified file
+        /// If the file doesn't exist null is returned (so can be used as kind of FileExists command
+        /// </summary>
+        /// <param name="filename">The file from where to retrieve the data.</param>
+        public FileEntity GetFileProperties(string filename)
+        {
+            if (filename == null) throw new ArgumentNullException();
+
+            FileEntity selectedFile = null;
+            string diskContent = this.GetDiskContent();
+
+            string[] filesArray = diskContent.Split(':');
+
+            for (int i = 1; i < filesArray.Length - 1; i++)
+            {
+                if (filesArray[i].LastIndexOf("File") == filesArray[i].Length - 4)
+                {
+                    filesArray[i] = filesArray[i].Substring(0, filesArray[i].Length - 4);
+                    string[] properties = filesArray[i].Split('\t');
+                    if (properties.Length == 3)
+                    {
+                        if (properties[2] == filename)
+                        {
+                            selectedFile = new FileEntity(properties[0], properties[1], properties[2]);
+                            break;
+                        }
+                    }
+                }
+            }
+            return selectedFile;
+        }
+        /// <summary>
+        /// Returns the content of a file as Byte Array. 
+        /// For UTF8 encoded data you can use the command 'PrintFile'
+        /// </summary>
+        /// <param name="filename">The file from where to retrieve the data.</param>
+        public byte[] GetFileDataBinary(string filename)
+        {
+            if (filename == null) throw new ArgumentNullException();
+            FileEntity selectedFile = this.GetFileProperties(filename);
+            if (selectedFile == null)
+            {
+                return null;
+            }
+            else
+            {
+                var cmd = this.GetCommand()
+                    .AddParameter(filename)
+                    .AddParameter("0")
+                    .AddParameter(selectedFile.Length)
+                   .Finalize(SPWF04SxCommandIds.FSP);
+                this.EnqueueCommand(cmd);
+                byte[] totalBuf = new byte[0];
+                byte[] lastBuf = new byte[0];
+                int offset = 0;
+                byte[] readBuf = new byte[50];
+                int len = readBuf.Length;
+                while (len > 0)
+                {
+                    len = cmd.ReadBuffer(readBuf, 0, len);
+                    lastBuf = totalBuf;
+                    offset = lastBuf.Length;
+                    totalBuf = new byte[offset + len];
+                    Array.Copy(lastBuf, 0, totalBuf, 0, offset);
+                    Array.Copy(readBuf, 0, totalBuf, offset, len);
+                    readBuf = new byte[len];
+                }
+                this.FinishCommand(cmd);
+                return totalBuf;
+            }
+        }
+
+
+        /// <summary>
+        /// Returns the content of a file as UTF8 string. Be sure that the file contains UTF8 compatible data.
+        /// For binary data use the command 'GetFileDataBinary'
+        /// </summary>
+        /// <param name="filename">The file from where to retrieve the data.</param>
+        public string PrintFile(string filename)
+        {
+            if (filename == null) throw new ArgumentNullException();
+
+            FileEntity selectedFile = this.GetFileProperties(filename);
+
+            if (selectedFile == null)
+            {
+                return null;
+            }
+            else
+            {
+                return Encoding.UTF8.GetString(this.GetFileDataBinary(filename));
+            }
+        }
+
+        /// <summary>
+        /// Deletes a file in Ram
+        /// </summary>
+        /// <param name="filename">The file to be deleted.</param>
+        public void DeleteRamFile(string filename)
+        {
+            if (filename == null) throw new ArgumentNullException();
+            if (this.GetFileProperties(filename) != null)
+            {
+                var cmd = this.GetCommand()
+                        .AddParameter(filename)
+                       .Finalize(SPWF04SxCommandIds.FSD);
+                this.EnqueueCommand(cmd);
+                cmd.ReadBuffer();
+                this.FinishCommand(cmd);
+            }
+        }
+
+        /// <summary>
+        /// Creates a file in Ram. If 'append' is false, an existing file with the same name is overwritten
+        /// </summary>
+        /// <param name="filename">The file to be created.</param>
+        /// <param name="rawData">The content of the file.</param>
+        /// <param name="append">When append is true, raw data are appended when a file with the same name already exists.</param>
+        public void CreateRamFile(string filename, byte[] rawData, bool append = false)
+        {
+            if (filename == null) throw new ArgumentNullException();
+            if (rawData == null) throw new ArgumentNullException();
+
+            if (append == false)
+            {
+                if (this.GetFileProperties(filename) != null)
+                {
+                    this.DeleteRamFile(filename);
+                }
+            }
+            var cmd = this.GetCommand()                     // Write rawData to file                
+                .AddParameter(filename)
+                .AddParameter((rawData.Length).ToString())
+                .Finalize(SPWF04SxCommandIds.FSC, rawData, 0, rawData.Length);
+            this.EnqueueCommand(cmd);
+            cmd.ReadBuffer();
+        }
+
+
+        public int SendHttpGet(string host, string path, int port, SPWF04SxConnectionSecurityType connectionSecurity, string in_filename, string out_filename, byte[] request)
+        {
+            if (this.activeHttpCommand != null) throw new InvalidOperationException();
+
+            DeleteRamFile(in_filename);              // Delete possibly existing in_filename
+            DeleteRamFile(out_filename);             // Delete possibly existing out_filename
+            CreateRamFile(out_filename, request);
+
+            this.activeHttpCommand = this.GetCommand()
+                .AddParameter(host)
+                .AddParameter(path)
+                .AddParameter(port.ToString())
+                .AddParameter(connectionSecurity == SPWF04SxConnectionSecurityType.None ? "0" : "2")
+                .AddParameter(null)
+                .AddParameter(null)
+                .AddParameter(in_filename)
+                .AddParameter(out_filename)
+                .Finalize(SPWF04SxCommandIds.HTTPGET);
+
+            this.EnqueueCommand(this.activeHttpCommand);
+
+            var result = this.activeHttpCommand.ReadString();
+            // Debug.WriteLine("1 " + result);
+            if (connectionSecurity == SPWF04SxConnectionSecurityType.Tls && result == string.Empty)
+            {
+                result = this.activeHttpCommand.ReadString();
+                if (result.IndexOf("Loading:") == 0)
+                    result = this.activeHttpCommand.ReadString();
+            }
+
+            // Changed by RoSchmi
+            try
+            {
+                return result.Split(':') is var parts && parts[0] == "Http Server Status Code" ? int.Parse(parts[1]) : throw new Exception($"Request failed: {result}");
+            }
+            catch (Exception ex)
+            {
+                return 99;
+            }
+        }
+
+        public int SendHttpPost(string host, string path, int port, SPWF04SxConnectionSecurityType connectionSecurity, string in_filename, string out_filename, byte[] request)
+        {
+            if (this.activeHttpCommand != null) throw new InvalidOperationException();
+
+            DeleteRamFile(in_filename);             // Delete possibly existing in_filename
+
+            DeleteRamFile(out_filename);             // Delete possibly existing out_filename
+
+            CreateRamFile(out_filename, request);
+
+            request = null;
+
+            GC.Collect();
+
+            this.activeHttpCommand = this.GetCommand()
+            .AddParameter(host)
+            .AddParameter(path)
+            .AddParameter(port.ToString())
+            .AddParameter(connectionSecurity == SPWF04SxConnectionSecurityType.None ? "0" : "2")
+            .AddParameter(null)
+            .AddParameter(null)
+            .AddParameter(in_filename)
+            .AddParameter(out_filename)
+            .Finalize(SPWF04SxCommandIds.HTTPPOST);
+
+            this.EnqueueCommand(this.activeHttpCommand);
+
+            var result = this.activeHttpCommand.ReadString();
+            if (connectionSecurity == SPWF04SxConnectionSecurityType.Tls && result == string.Empty)
+            {
+                result = this.activeHttpCommand.ReadString();
+
+                if (result.IndexOf("Loading:") == 0)
+                    result = this.activeHttpCommand.ReadString();
+            }
+
+            return result.Split(':') is var parts && parts[0] == "Http Server Status Code" ? int.Parse(parts[1]) : throw new Exception($"Request failed: {result}");
+        }
+
+        public string SendPing(string hostname, string counter = "1", string size = "56")
+        {
+            var cmd = this.GetCommand()
+            .AddParameter(counter)
+            .AddParameter(size)
+            .AddParameter(hostname)
+            .Finalize(SPWF04SxCommandIds.PING);
+
+            this.EnqueueCommand(cmd);
+
+            byte[] totalBuf = new byte[0];
+            byte[] lastBuf = new byte[0];
+            int offset = 0;
+            byte[] readBuf = new byte[50];
+            int len = readBuf.Length;
+            while (len > 0)
+            {
+                len = cmd.ReadBuffer(readBuf, 0, len);
+                lastBuf = totalBuf;
+                offset = lastBuf.Length;
+                totalBuf = new byte[offset + len];
+                Array.Copy(lastBuf, 0, totalBuf, 0, offset);
+                Array.Copy(readBuf, 0, totalBuf, offset, len);
+                readBuf = new byte[len];
+                Thread.Sleep(1000);
+            }
+            this.FinishCommand(cmd);
+            return Encoding.UTF8.GetString(totalBuf);
+        }
+
+
+        //*************************************** End added by RoSchmi  ***************************************************
+
+
+
         public int SendHttpGet(string host, string path, int port, SPWF04SxConnectionSecurityType connectionSecurity) {
             if (this.activeHttpCommand != null) throw new InvalidOperationException();
 
@@ -263,19 +691,38 @@ namespace GHIElectronics.TinyCLR.Drivers.STMicroelectronics.SPWF04Sx {
                 .AddParameter(commonName ?? (connectionType == SPWF04SxConnectionType.Tcp ? (connectionSecurity == SPWF04SxConnectionSecurityType.Tls ? "s" : "t") : "u"))
                 .Finalize(SPWF04SxCommandIds.SOCKON);
 
+            // Changed by RoSchmi
+            SocketErrorHappened = false;
             this.EnqueueCommand(cmd);
-
-            var a = cmd.ReadString();
-            var b = cmd.ReadString();
-
-            if (connectionSecurity == SPWF04SxConnectionSecurityType.Tls && b.IndexOf("Loading:") == 0) {
-                a = cmd.ReadString();
-                b = cmd.ReadString();
+            Thread.Sleep(0);
+            string a = string.Empty;
+            string b = string.Empty;
+            if (!SocketErrorHappened)
+            {
+                a = cmd.ReadString();                
+                Thread.Sleep(0);
+                if (!SocketErrorHappened)
+                {
+                    b = cmd.ReadString();                    
+                }
+                Thread.Sleep(0);
+                if (connectionSecurity == SPWF04SxConnectionSecurityType.Tls && b.IndexOf("Loading:") == 0)
+                {
+                    if (!SocketErrorHappened)
+                    {
+                        a = cmd.ReadString();                       
+                    }
+                    Thread.Sleep(0);
+                    if (!SocketErrorHappened)
+                    {
+                        b = cmd.ReadString();                       
+                    }
+                }               
             }
+            this.FinishCommand(cmd);          
 
-            this.FinishCommand(cmd);
-
-            return a.Split(':') is var result && result[0] == "On" ? int.Parse(result[2]) : throw new Exception("Request failed");
+            //return a.Split(':') is var result && result[0] == "On" ? int.Parse(result[2]) : throw new Exception("Request failed");
+            return a.Split(':') is var result && result[0] == "On" ? int.Parse(result[2]) : -1;
         }
 
         public void CloseSocket(int socket) {
@@ -358,7 +805,8 @@ namespace GHIElectronics.TinyCLR.Drivers.STMicroelectronics.SPWF04Sx {
             while (cmd.ReadString() is var s && s != string.Empty)
                 str += s + Environment.NewLine;
 
-            cmd.ReadBuffer();
+            // changed by RoSchmi
+            // cmd.ReadBuffer();
 
             this.FinishCommand(cmd);
 
@@ -497,6 +945,87 @@ namespace GHIElectronics.TinyCLR.Drivers.STMicroelectronics.SPWF04Sx {
                             //        break;
                             //}
 
+                            switch (ind)
+                            {
+
+                                case 0x00:
+                                    {
+                                        // OK - for command without payload or after the last chunk of data of an answer on a command
+                                        // Debug.WriteLine("Indication: " + ind.ToString("X2") + " AT-S.OK without payload. " + "PayLoad = " + payloadLength.ToString());
+                                    }
+                                    break;
+                                case 0x02:
+                                    {
+                                        // Seen, actually meaning not clear
+                                        //Debug.WriteLine("Indication: " + ind.ToString("X2") + " PayLoad = " + payloadLength.ToString());
+                                    }
+                                    break;
+                                case 0x03:
+                                    {
+                                        // Seen after FSP Command
+                                        //Debug.WriteLine("Indication: " + ind.ToString("X2") + " PayLoad = " + payloadLength.ToString());                                       
+                                    }
+                                    break;
+                                case 0x04:
+                                    {
+                                        // Seen after bad formed configuration command
+                                        Debug.WriteLine("Indication: " + ind.ToString("X2") + " Wrong command format " + " Pld = " + payloadLength.ToString());
+                                    }
+                                    break;
+
+                                case 0x2C:  // dec 44: wait for connection up
+                                    {
+                                        SocketErrorHappened = true;
+                                        Debug.WriteLine("Indication: " + ind.ToString("X2") + " Wait for connection up " + " Pld = " + payloadLength.ToString());
+                                    }
+                                    break;
+                                case 0x38:  // dec 56: Unable to delete file ?
+                                    {
+                                        Debug.WriteLine("Ind: " + ind.ToString("X2") + " Unable to delete file" + " Pld = " + payloadLength.ToString());
+                                    }
+                                    break;
+                                case 0x41:  // dez 65: DNS Address Failure
+                                    {
+                                        SocketErrorHappened = true;
+                                        Debug.WriteLine("Indication: " + ind.ToString("X2") + " DNS Address failed " + " Pld = " + payloadLength.ToString());
+                                    }
+                                    break;
+
+                                case 0x4A:   // dec 77: Failed to open socket  
+                                    {
+                                        SocketErrorHappened = true;
+                                        Debug.WriteLine("Ind: " + ind.ToString("X2") + " Failed to open socket " + " Pld = " + payloadLength.ToString());
+                                    }
+                                    break;
+                                case 0x4C:   // dec 79: Write failed
+                                    {
+                                        SocketErrorHappened = true;
+                                        Debug.WriteLine("Ind: " + ind.ToString("X2") + " Write failed " + " Pld = " + payloadLength.ToString());
+                                    }
+                                    break;
+                                case 0x6F:   // dez 111 Request failed
+                                    {
+                                        Debug.WriteLine("Ind: " + ind.ToString("X2") + " Request failed " + " Pld = " + payloadLength.ToString());
+                                    }
+                                    break;
+                                case 0xFF:
+                                    {
+                                        // For (following) First or consecutive chunks of data of an answer on a command
+                                        // Debug.WriteLine("Indication: " + ind.ToString("X2") + " consecutive chunk of answer. " + "PayLoad = " + payloadLength.ToString());
+                                    }
+                                    break;
+                                case 0xFE:
+                                    {
+                                        // For the first chunk of data of an answer on a command 
+                                        // Debug.WriteLine("Indication: " + ind.ToString("X2") + " First chunk (sentence?) of answer. " + "PayLoad = " + payloadLength.ToString());
+                                    }
+                                    break;
+                                default:
+                                    {
+                                        Debug.WriteLine("AT-S.ERROR x " + "Indication: " + ind.ToString("X2") + " Pld = " + payloadLength.ToString());
+                                    }
+                                    break;
+                            }
                             this.activeCommand.ReadPayload(this.spi.Read, payloadLength);
                         }
                         else {


### PR DESCRIPTION
Added several commands to SPWF04SA driver.
Analyzed the meaning of several Type 03 Ind messages. 
Created a variable 'SocketErrorHappened' for events when opening of a socket failed.
When opening failed I return the AT+S.SOCKON cmd with -1, meaning that an error occured. So I can retry or finally return a httpStatusCode showing that opening of the socket failed,
For details how to use, see my GitHub project 'RoSchmi/AzureDataSender_FEZ'
