### PR TITLE
- Library to support Microchip Mcp23xxx series Gpio expanders

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,10 @@ end_of_line = crlf
 charset = utf-8
 trim_trailing_whitespace = true
 
+# Microsoft .NET properties
+csharp_indent_braces = false
+csharp_new_line_before_open_brace = all
+
 [*.{cs,csx,vb,vbx}]
 indent_size = 4
 insert_final_newline = true

--- a/GHIElectronics.TinyCLR.Drivers.sln
+++ b/GHIElectronics.TinyCLR.Drivers.sln
@@ -81,6 +81,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GHIElectronics.TinyCLR.Driv
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GHIElectronics.TinyCLR.Drivers.Encoder", "Encoder\GHIElectronics.TinyCLR.Drivers.Encoder.csproj", "{826F2BEA-28F6-46F9-AA7B-9E853551DF24}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx", "Microchip\Mcp23xxx\GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx\GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.csproj", "{4DAE42D1-9BE6-47A5-93C1-4347A06746D4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -243,6 +245,10 @@ Global
 		{826F2BEA-28F6-46F9-AA7B-9E853551DF24}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{826F2BEA-28F6-46F9-AA7B-9E853551DF24}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{826F2BEA-28F6-46F9-AA7B-9E853551DF24}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4DAE42D1-9BE6-47A5-93C1-4347A06746D4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4DAE42D1-9BE6-47A5-93C1-4347A06746D4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4DAE42D1-9BE6-47A5-93C1-4347A06746D4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4DAE42D1-9BE6-47A5-93C1-4347A06746D4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/GHIElectronics.TinyCLR.Drivers.sln
+++ b/GHIElectronics.TinyCLR.Drivers.sln
@@ -83,6 +83,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GHIElectronics.TinyCLR.Driv
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx", "Microchip\Mcp23xxx\GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx\GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.csproj", "{4DAE42D1-9BE6-47A5-93C1-4347A06746D4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GHIElectronics.TinyCLR.Drivers.MemoryManager", "MemoryManager\GHIElectronics.TinyCLR.Drivers.MemoryManager\GHIElectronics.TinyCLR.Drivers.MemoryManager.csproj", "{D21B4747-8955-4D13-AC38-8F7C6840F5ED}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -249,6 +251,10 @@ Global
 		{4DAE42D1-9BE6-47A5-93C1-4347A06746D4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4DAE42D1-9BE6-47A5-93C1-4347A06746D4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4DAE42D1-9BE6-47A5-93C1-4347A06746D4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D21B4747-8955-4D13-AC38-8F7C6840F5ED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D21B4747-8955-4D13-AC38-8F7C6840F5ED}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D21B4747-8955-4D13-AC38-8F7C6840F5ED}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D21B4747-8955-4D13-AC38-8F7C6840F5ED}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/MemoryManager/GHIElectronics.TinyCLR.Drivers.MemoryManager/GHIElectronics.TinyCLR.Drivers.MemoryManager.csproj
+++ b/MemoryManager/GHIElectronics.TinyCLR.Drivers.MemoryManager/GHIElectronics.TinyCLR.Drivers.MemoryManager.csproj
@@ -1,0 +1,68 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\GHIElectronics.TinyCLR.Core.2.1.0\build\net452\GHIElectronics.TinyCLR.Core.props" Condition="Exists('..\..\packages\GHIElectronics.TinyCLR.Core.2.1.0\build\net452\GHIElectronics.TinyCLR.Core.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{D21B4747-8955-4D13-AC38-8F7C6840F5ED}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>GHIElectronics.TinyCLR.Drivers.MemoryManager</RootNamespace>
+    <AssemblyName>GHIElectronics.TinyCLR.Drivers.MemoryManager</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{A1948822-69DD-4150-919B-F3F42EFB71CC};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <LangVersion>9</LangVersion>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="IMemoryInterface.cs" />
+    <Compile Include="MemoryManager.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RtcMemory\RtcMemoryInterface.cs" />
+    <Compile Include="SecureMemory\SecureStorageInterface.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="GHIElectronics.TinyCLR.Cryptography, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GHIElectronics.TinyCLR.Cryptography.2.1.0\lib\net452\GHIElectronics.TinyCLR.Cryptography.dll</HintPath>
+    </Reference>
+    <Reference Include="GHIElectronics.TinyCLR.Devices.Rtc, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GHIElectronics.TinyCLR.Devices.Rtc.2.1.0\lib\net452\GHIElectronics.TinyCLR.Devices.Rtc.dll</HintPath>
+    </Reference>
+    <Reference Include="GHIElectronics.TinyCLR.Devices.SecureStorage, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GHIElectronics.TinyCLR.Devices.SecureStorage.2.1.0\lib\net452\GHIElectronics.TinyCLR.Devices.SecureStorage.dll</HintPath>
+    </Reference>
+    <Reference Include="GHIElectronics.TinyCLR.Native, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GHIElectronics.TinyCLR.Native.2.1.0\lib\net452\GHIElectronics.TinyCLR.Native.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\GHIElectronics.TinyCLR.Core.2.1.0\build\net452\GHIElectronics.TinyCLR.Core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\GHIElectronics.TinyCLR.Core.2.1.0\build\net452\GHIElectronics.TinyCLR.Core.props'))" />
+  </Target>
+</Project>

--- a/MemoryManager/GHIElectronics.TinyCLR.Drivers.MemoryManager/GHIElectronics.TinyCLR.Drivers.MemoryManager.csproj
+++ b/MemoryManager/GHIElectronics.TinyCLR.Drivers.MemoryManager/GHIElectronics.TinyCLR.Drivers.MemoryManager.csproj
@@ -42,21 +42,21 @@
     <Compile Include="SecureMemory\SecureStorageInterface.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <Reference Include="GHIElectronics.TinyCLR.Cryptography">
+      <HintPath>..\..\..\TinyCLR-Libraries\GHIElectronics.TinyCLR.Cryptography\bin\Debug\GHIElectronics.TinyCLR.Cryptography.dll</HintPath>
+    </Reference>
+    <Reference Include="GHIElectronics.TinyCLR.Devices.Rtc">
+      <HintPath>..\..\..\TinyCLR-Libraries\GHIElectronics.TinyCLR.Devices.Rtc\bin\Debug\GHIElectronics.TinyCLR.Devices.Rtc.dll</HintPath>
+    </Reference>
+    <Reference Include="GHIElectronics.TinyCLR.Devices.SecureStorage">
+      <HintPath>..\..\..\TinyCLR-Libraries\GHIElectronics.TinyCLR.Devices.SecureStorage\bin\Debug\GHIElectronics.TinyCLR.Devices.SecureStorage.dll</HintPath>
+    </Reference>
+    <Reference Include="GHIElectronics.TinyCLR.Native">
+      <HintPath>..\..\..\TinyCLR-Libraries\GHIElectronics.TinyCLR.Native\bin\Debug\GHIElectronics.TinyCLR.Native.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="GHIElectronics.TinyCLR.Cryptography, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GHIElectronics.TinyCLR.Cryptography.2.1.0\lib\net452\GHIElectronics.TinyCLR.Cryptography.dll</HintPath>
-    </Reference>
-    <Reference Include="GHIElectronics.TinyCLR.Devices.Rtc, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GHIElectronics.TinyCLR.Devices.Rtc.2.1.0\lib\net452\GHIElectronics.TinyCLR.Devices.Rtc.dll</HintPath>
-    </Reference>
-    <Reference Include="GHIElectronics.TinyCLR.Devices.SecureStorage, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GHIElectronics.TinyCLR.Devices.SecureStorage.2.1.0\lib\net452\GHIElectronics.TinyCLR.Devices.SecureStorage.dll</HintPath>
-    </Reference>
-    <Reference Include="GHIElectronics.TinyCLR.Native, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GHIElectronics.TinyCLR.Native.2.1.0\lib\net452\GHIElectronics.TinyCLR.Native.dll</HintPath>
-    </Reference>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/MemoryManager/GHIElectronics.TinyCLR.Drivers.MemoryManager/IMemoryInterface.cs
+++ b/MemoryManager/GHIElectronics.TinyCLR.Drivers.MemoryManager/IMemoryInterface.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Diagnostics;
 using System.Text;
+
 using GHIElectronics.TinyCLR.Cryptography;
 
 // ReSharper disable InconsistentNaming
@@ -12,185 +13,196 @@ using GHIElectronics.TinyCLR.Cryptography;
 
 namespace GHIElectronics.TinyCLR.Drivers.MemoryManager
 {
-	public interface IMemoryInterface
-	{
-		internal uint Size { get; }
-		internal Hashtable Deserialize(out uint usedMemory);
-		internal bool Serialize(Hashtable data);
-		internal void Dump();
-	}
+    public interface IMemoryInterface
+    {
+        internal uint Size { get; }
+        internal bool Deserialize(out Hashtable data, out uint usedMemory);
+        internal bool Serialize(Hashtable data);
+        internal void Dump(StringBuilder sb);
+    }
 
-	public abstract class MemoryInterfaceBase
-	{
-		protected readonly byte[] Sentinel = { 0x5a, 0xa5 };
-		protected byte DataCountSize = sizeof(ushort); // 2, allows up to 65535 bytes to be serialized
-		private const byte KeySize = sizeof(byte); // 1, allows up to 256 keys
-		private const byte TypeSize = sizeof(byte); // 1, allows up to 256 data types to be defined
-		protected byte DynamicTypeSize = sizeof(ushort); // allows up to 65535 bytes for dynamically sized types (string/byte[])
-		protected readonly Crc16 Crc = new();
-		protected const byte CrcSize = sizeof(ushort);
+    public abstract class MemoryInterfaceBase
+    {
+        protected readonly byte[] Sentinel = { 0x5a, 0xa5 };
+        protected byte DataCountSize = sizeof(ushort); // default allows up to 65535 bytes to be serialized
+        private const byte KeySize = sizeof(byte); // allows up to 256 keys
+        private const byte TypeSize = sizeof(byte); // allows up to 256 data types to be defined
+        protected byte DynamicTypeSize = sizeof(ushort); // default allows up to 65535 bytes for dynamically sized types (string/byte[])
+        protected readonly Crc16 Crc = new();
+        protected const byte CrcSize = sizeof(ushort);
 
-		#region enum
+        #region enum
 
-		private enum DataType
-		{
-			///<summary> represents an <see cref="Array"/> of <see cref="byte"/> </summary>
-			ByteArray,
-			///<summary> represents a <see cref="byte"/> </summary>
-			Byte,
-			///<summary> represents an <see cref="sbyte"/> </summary>
-			SByte,
-			///<summary> represents a <see cref="bool"/> </summary>
-			Bool,
-			///<summary> represents a <see cref="short"/> </summary>
-			Short,
-			///<summary> represents a <see cref="ushort"/> </summary>
-			UShort,
-			///<summary> represents a <see cref="int"/> </summary>
-			Int,
-			///<summary> represents a <see cref="uint"/> </summary>
-			UInt,
-			///<summary> represents a <see cref="float"/> </summary>
-			Float,
-			///<summary> represents a <see cref="long"/> </summary>
-			Long,
-			///<summary> represents a <see cref="ulong"/> </summary>
-			ULong,
-			///<summary> represents a <see cref="double"/> </summary>
-			Double,
-			///<summary> represents a <see cref="char"/> </summary>
-			Char,
-			///<summary> represents a <see cref="string"/> </summary>
-			String
-		}
+        private enum DataType : byte
+        {
+            ///<summary> represents an <see cref="Array"/> of <see cref="byte"/> </summary>
+            ByteArray,
 
-		#endregion enum
+            ///<summary> represents a <see cref="byte"/> </summary>
+            Byte,
 
-		/// <summary>
-		/// Encodes data according to its type
-		/// </summary>
-		/// <param name="entry"> Key value pairing of data </param>
-		/// <param name="encoded"> Encoded data of <see cref="entry"/> </param>
-		/// <returns> Length of Encoded data </returns>
-		protected ushort Encode(DictionaryEntry entry, out byte[] encoded)
-		{
-			var index = 0;
-			encoded = entry.Value switch
-			{
-				byte[] bytes => EncodeDynamicType(bytes, DataType.ByteArray),
-				byte @byte => EncodePrimitiveType(new[] { @byte }, DataType.Byte),
-				sbyte @sbyte => EncodePrimitiveType(new[] { unchecked((byte)@sbyte) }, DataType.SByte),
-				bool @bool => EncodePrimitiveType(BitConverter.GetBytes(@bool), DataType.Bool),
-				short @short => EncodePrimitiveType(BitConverter.GetBytes(@short), DataType.Short),
-				ushort @ushort => EncodePrimitiveType(BitConverter.GetBytes(@ushort), DataType.UShort),
-				int @int => EncodePrimitiveType(BitConverter.GetBytes(@int), DataType.Int),
-				uint @uint => EncodePrimitiveType(BitConverter.GetBytes(@uint), DataType.UInt),
-				float @float => EncodePrimitiveType(BitConverter.GetBytes(@float), DataType.Float),
-				long @long => EncodePrimitiveType(BitConverter.GetBytes(@long), DataType.Long),
-				ulong @ulong => EncodePrimitiveType(BitConverter.GetBytes(@ulong), DataType.ULong),
-				double @double => EncodePrimitiveType(BitConverter.GetBytes(@double), DataType.Double),
-				char @char => EncodeDynamicType(BitConverter.GetBytes(@char), DataType.Char),
-				string @string => EncodeDynamicType(Encoding.UTF8.GetBytes(@string), DataType.String),
-				_ => throw new ArgumentOutOfRangeException($"{nameof(entry.Value)}", $"Unrecognized type to be encoded to memory stream: {entry.Value}")
+            ///<summary> represents an <see cref="sbyte"/> </summary>
+            SByte,
 
-			};
-			return (ushort)encoded.Length;
+            ///<summary> represents a <see cref="bool"/> </summary>
+            Bool,
 
-			byte[] EncodeDynamicType(byte[] bytes, DataType dataType)
-			{
-				if (bytes == null) throw new ArgumentNullException(nameof(bytes));
-				var encode = new byte[KeySize + TypeSize + this.DynamicTypeSize + bytes.Length];
-				encode[index] = (byte)entry.Key; // ToDo abstract hard size
-				encode[index += KeySize] = (byte)dataType;
-				var dynamicSize = BitConverter.GetBytes((ushort)bytes.Length);
-				Array.Copy(dynamicSize, 0, encode, index += TypeSize, dynamicSize.Length);
-				Array.Copy(bytes, 0, encode, index + dynamicSize.Length, bytes.Length);
-				return encode;
-			}
+            ///<summary> represents a <see cref="short"/> </summary>
+            Short,
 
-			byte[] EncodePrimitiveType(byte[] bytes, DataType dataType)
-			{
-				if (bytes == null) throw new ArgumentNullException(nameof(bytes));
-				var encode = new byte[KeySize + TypeSize + bytes.Length];
-				encode[index] = (byte)entry.Key; // ToDo abstract hard size
-				encode[index += KeySize] = (byte)dataType;
-				Array.Copy(bytes, 0, encode, index + TypeSize, bytes.Length);
-				return encode;
-			}
-		}
+            ///<summary> represents a <see cref="ushort"/> </summary>
+            UShort,
 
-		/// <summary>
-		/// Decode data stream
-		/// </summary>
-		/// <param name="data"> Data to decode </param>
-		/// <param name="count"> running count of individual data chunks in data stream </param>
-		/// <returns> Individual data chunk value </returns>
-		/// <exception cref="ArgumentNullException"> Thrown when <see cref="data"/> is null. </exception>
-		/// <exception cref="ArgumentOutOfRangeException"> Thrown value read from memory stream is not a known data type <see cref="DataType"/>. </exception>
-		protected object Decode(byte[] data, ref object count)
-		{
-			if (data == null) throw new ArgumentNullException(nameof(data));
-			var i = (ushort)count;
-			var type = (DataType)data[i += KeySize];
+            ///<summary> represents a <see cref="int"/> </summary>
+            Int,
 
-			i += TypeSize; // move to data
-			var decoded = type switch
-			{
-				DataType.ByteArray => ByteArrayType(),
-				DataType.Byte => new object[] { data[i], sizeof(byte) },
-				DataType.SByte => new object[] { unchecked((sbyte)data[i]), sizeof(sbyte) },
-				DataType.Bool => new object[] { BitConverter.ToBoolean(data, i), sizeof(bool) },
-				DataType.Short => new object[] { BitConverter.ToInt16(data, i), sizeof(short) },
-				DataType.UShort => new object[] { BitConverter.ToUInt16(data, i), sizeof(ushort) },
-				DataType.Int => new object[] { BitConverter.ToInt32(data, i), sizeof(int) },
-				DataType.UInt => new object[] { BitConverter.ToUInt32(data, i), sizeof(uint) },
-				DataType.Float => new object[] { BitConverter.ToSingle(data, i), sizeof(float) },
-				DataType.Long => new object[] { BitConverter.ToInt64(data, i), sizeof(long) },
-				DataType.ULong => new object[] { BitConverter.ToUInt64(data, i), sizeof(ulong) },
-				DataType.Double => new object[] { BitConverter.ToDouble(data, i), sizeof(double) },
-				DataType.Char => new object[] { BitConverter.ToChar(data, i += this.DynamicTypeSize), sizeof(char) },
-				DataType.String => StringType(),
-				_ => throw new ArgumentOutOfRangeException($"{nameof(data)}", $"Unrecognized type decoded in memory stream: {type}")
+            ///<summary> represents a <see cref="uint"/> </summary>
+            UInt,
 
-			};
+            ///<summary> represents a <see cref="float"/> </summary>
+            Float,
 
-			var value = decoded[0];
-			i += (ushort)((int)(decoded[1])); // move to end
+            ///<summary> represents a <see cref="long"/> </summary>
+            Long,
 
-			count = i;
-			return value;
+            ///<summary> represents a <see cref="ulong"/> </summary>
+            ULong,
 
-			object[] ByteArrayType()
-			{
-				int dynamicTypeCount = BitConverter.ToUInt16(data, i);
-				value = new byte[dynamicTypeCount];
-				Array.Copy(data, i += this.DynamicTypeSize, (byte[])value, 0, dynamicTypeCount);
-				return new[] { value, dynamicTypeCount };
-			}
+            ///<summary> represents a <see cref="double"/> </summary>
+            Double,
 
-			object[] StringType()
-			{
-				int dynamicTypeCount = BitConverter.ToUInt16(data, i);
-				return new object[] { Encoding.UTF8.GetString(data, i += this.DynamicTypeSize, dynamicTypeCount), dynamicTypeCount };
-			}
-		}
+            ///<summary> represents a <see cref="char"/> </summary>
+            Char,
 
-		/// <summary> Header for printable memory dump </summary>
-		/// <remarks> For debugging </remarks>
-		/// <returns> Header for printable memory dump </returns>
-		protected static StringBuilder Dump()
-		{
-			var sb = new StringBuilder(32);
-			sb.Append("     ");
-			for (var i = 0; i < 32; i++)
-				sb.Append($"{i,0x03} ");
-			sb.AppendLine();
-			sb.Append("     ");
-			for (var i = 0; i < 32; i++)
-				sb.Append("----");
-			Debug.WriteLine(sb.ToString());
-			sb.Clear();
-			return sb;
-		}
-	}
+            ///<summary> represents a <see cref="string"/> </summary>
+            String
+        }
+
+        #endregion enum
+
+        /// <summary> Encodes data according to its type </summary>
+        /// <param name="entry"> Key value pairing of data </param>
+        /// <param name="encoded"> Encoded data of <see cref="entry"/> </param>
+        /// <returns> Length of encoded data </returns>
+        protected ushort Encode(DictionaryEntry entry, out byte[] encoded)
+        {
+            var index = 0;
+            encoded = entry.Value switch
+            {
+                byte[] bytes => EncodeDynamicType(bytes, DataType.ByteArray),
+                byte @byte => EncodePrimitiveType(new[] { @byte }, DataType.Byte),
+                sbyte @sbyte => EncodePrimitiveType(new[] { unchecked((byte)@sbyte) }, DataType.SByte),
+                bool @bool => EncodePrimitiveType(BitConverter.GetBytes(@bool), DataType.Bool),
+                short @short => EncodePrimitiveType(BitConverter.GetBytes(@short), DataType.Short),
+                ushort @ushort => EncodePrimitiveType(BitConverter.GetBytes(@ushort), DataType.UShort),
+                int @int => EncodePrimitiveType(BitConverter.GetBytes(@int), DataType.Int),
+                uint @uint => EncodePrimitiveType(BitConverter.GetBytes(@uint), DataType.UInt),
+                float @float => EncodePrimitiveType(BitConverter.GetBytes(@float), DataType.Float),
+                long @long => EncodePrimitiveType(BitConverter.GetBytes(@long), DataType.Long),
+                ulong @ulong => EncodePrimitiveType(BitConverter.GetBytes(@ulong), DataType.ULong),
+                double @double => EncodePrimitiveType(BitConverter.GetBytes(@double), DataType.Double),
+                char @char => EncodeDynamicType(BitConverter.GetBytes(@char), DataType.Char),
+                string @string => EncodeDynamicType(Encoding.UTF8.GetBytes(@string), DataType.String),
+                _ => throw new ArgumentOutOfRangeException($"{nameof(entry.Value)}", $"Unrecognized type to be encoded to memory stream: {entry.Value}")
+
+            };
+            return (ushort)encoded.Length;
+
+            byte[] EncodeDynamicType(byte[] bytes, DataType dataType)
+            {
+                if (bytes == null) throw new ArgumentNullException(nameof(bytes));
+
+                var encode = new byte[KeySize + TypeSize + DynamicTypeSize + bytes.Length];
+                encode[index] = (byte)entry.Key;
+                encode[index += KeySize] = (byte)dataType;
+                var dynamicSize = BitConverter.GetBytes((ushort)bytes.Length);
+                Array.Copy(dynamicSize, 0, encode, index += TypeSize, dynamicSize.Length);
+                Array.Copy(bytes, 0, encode, index + dynamicSize.Length, bytes.Length);
+                return encode;
+            }
+
+            byte[] EncodePrimitiveType(byte[] bytes, DataType dataType)
+            {
+                if (bytes == null) throw new ArgumentNullException(nameof(bytes));
+
+                var encode = new byte[KeySize + TypeSize + bytes.Length];
+                encode[index] = (byte)entry.Key;
+                encode[index += KeySize] = (byte)dataType;
+                Array.Copy(bytes, 0, encode, index + TypeSize, bytes.Length);
+                return encode;
+            }
+        }
+
+        /// <summary> Decode data stream </summary>
+        /// <param name="data"> Data to decode </param>
+        /// <param name="count"> Running count of individual data chunks in data stream </param>
+        /// <returns> Individual data chunk value </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <see cref="data"/> is null. </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> Thrown value read from memory stream is not a known data type <see cref="DataType"/>. </exception>
+        protected object Decode(byte[] data, ref object count)
+        {
+            if (data == null) throw new ArgumentNullException(nameof(data));
+
+            var i = (ushort)count;
+            var type = (DataType)data[i += KeySize];
+
+            i += TypeSize; // move to data
+            var decoded = type switch
+            {
+                DataType.ByteArray => ByteArrayType(),
+                DataType.Byte => new object[] { data[i], sizeof(byte) },
+                DataType.SByte => new object[] { unchecked((sbyte)data[i]), sizeof(sbyte) },
+                DataType.Bool => new object[] { BitConverter.ToBoolean(data, i), sizeof(bool) },
+                DataType.Short => new object[] { BitConverter.ToInt16(data, i), sizeof(short) },
+                DataType.UShort => new object[] { BitConverter.ToUInt16(data, i), sizeof(ushort) },
+                DataType.Int => new object[] { BitConverter.ToInt32(data, i), sizeof(int) },
+                DataType.UInt => new object[] { BitConverter.ToUInt32(data, i), sizeof(uint) },
+                DataType.Float => new object[] { BitConverter.ToSingle(data, i), sizeof(float) },
+                DataType.Long => new object[] { BitConverter.ToInt64(data, i), sizeof(long) },
+                DataType.ULong => new object[] { BitConverter.ToUInt64(data, i), sizeof(ulong) },
+                DataType.Double => new object[] { BitConverter.ToDouble(data, i), sizeof(double) },
+                DataType.Char => new object[] { BitConverter.ToChar(data, i += DynamicTypeSize), sizeof(char) },
+                DataType.String => StringType(),
+                _ => throw new ArgumentOutOfRangeException($"{nameof(data)}", $"Unrecognized type decoded in memory stream: {type}")
+
+            };
+
+            var value = decoded[0];
+            i += (ushort)((int)(decoded[1])); // move to end
+
+            count = i;
+            return value;
+
+            object[] ByteArrayType()
+            {
+                int dynamicTypeCount = BitConverter.ToUInt16(data, i);
+                value = new byte[dynamicTypeCount];
+                Array.Copy(data, i += DynamicTypeSize, (byte[])value, 0, dynamicTypeCount);
+                return new[] { value, dynamicTypeCount };
+            }
+
+            object[] StringType()
+            {
+                int dynamicTypeCount = BitConverter.ToUInt16(data, i);
+                return new object[] { Encoding.UTF8.GetString(data, i += DynamicTypeSize, dynamicTypeCount), dynamicTypeCount };
+            }
+        }
+
+        /// <summary> Common header for printable memory dump </summary>
+        /// <remarks> Used for debugging </remarks>
+        /// <returns> string building used to dump memory </returns>
+        protected static StringBuilder Dump(StringBuilder sb)
+        {
+            sb.Append("     ");
+            for (var i = 0; i < 32; i++)
+                sb.Append($"{i,0x03} ");
+            sb.AppendLine();
+            sb.Append("     ");
+            for (var i = 0; i < 32; i++)
+                sb.Append("----");
+            Debug.WriteLine(sb.ToString());
+            sb.Clear();
+            return sb;
+        }
+    }
 }

--- a/MemoryManager/GHIElectronics.TinyCLR.Drivers.MemoryManager/IMemoryInterface.cs
+++ b/MemoryManager/GHIElectronics.TinyCLR.Drivers.MemoryManager/IMemoryInterface.cs
@@ -1,0 +1,196 @@
+using System;
+using System.Collections;
+using System.Diagnostics;
+using System.Text;
+using GHIElectronics.TinyCLR.Cryptography;
+
+// ReSharper disable InconsistentNaming
+// ReSharper disable ArrangeThisQualifier
+#pragma warning disable IDE1006 // Naming Styles
+#pragma warning disable IDE0009 // Member access should be qualified.
+
+
+namespace GHIElectronics.TinyCLR.Drivers.MemoryManager
+{
+	public interface IMemoryInterface
+	{
+		internal uint Size { get; }
+		internal Hashtable Deserialize(out uint usedMemory);
+		internal bool Serialize(Hashtable data);
+		internal void Dump();
+	}
+
+	public abstract class MemoryInterfaceBase
+	{
+		protected readonly byte[] Sentinel = { 0x5a, 0xa5 };
+		protected byte DataCountSize = sizeof(ushort); // 2, allows up to 65535 bytes to be serialized
+		private const byte KeySize = sizeof(byte); // 1, allows up to 256 keys
+		private const byte TypeSize = sizeof(byte); // 1, allows up to 256 data types to be defined
+		protected byte DynamicTypeSize = sizeof(ushort); // allows up to 65535 bytes for dynamically sized types (string/byte[])
+		protected readonly Crc16 Crc = new();
+		protected const byte CrcSize = sizeof(ushort);
+
+		#region enum
+
+		private enum DataType
+		{
+			///<summary> represents an <see cref="Array"/> of <see cref="byte"/> </summary>
+			ByteArray,
+			///<summary> represents a <see cref="byte"/> </summary>
+			Byte,
+			///<summary> represents an <see cref="sbyte"/> </summary>
+			SByte,
+			///<summary> represents a <see cref="bool"/> </summary>
+			Bool,
+			///<summary> represents a <see cref="short"/> </summary>
+			Short,
+			///<summary> represents a <see cref="ushort"/> </summary>
+			UShort,
+			///<summary> represents a <see cref="int"/> </summary>
+			Int,
+			///<summary> represents a <see cref="uint"/> </summary>
+			UInt,
+			///<summary> represents a <see cref="float"/> </summary>
+			Float,
+			///<summary> represents a <see cref="long"/> </summary>
+			Long,
+			///<summary> represents a <see cref="ulong"/> </summary>
+			ULong,
+			///<summary> represents a <see cref="double"/> </summary>
+			Double,
+			///<summary> represents a <see cref="char"/> </summary>
+			Char,
+			///<summary> represents a <see cref="string"/> </summary>
+			String
+		}
+
+		#endregion enum
+
+		/// <summary>
+		/// Encodes data according to its type
+		/// </summary>
+		/// <param name="entry"> Key value pairing of data </param>
+		/// <param name="encoded"> Encoded data of <see cref="entry"/> </param>
+		/// <returns> Length of Encoded data </returns>
+		protected ushort Encode(DictionaryEntry entry, out byte[] encoded)
+		{
+			var index = 0;
+			encoded = entry.Value switch
+			{
+				byte[] bytes => EncodeDynamicType(bytes, DataType.ByteArray),
+				byte @byte => EncodePrimitiveType(new[] { @byte }, DataType.Byte),
+				sbyte @sbyte => EncodePrimitiveType(new[] { unchecked((byte)@sbyte) }, DataType.SByte),
+				bool @bool => EncodePrimitiveType(BitConverter.GetBytes(@bool), DataType.Bool),
+				short @short => EncodePrimitiveType(BitConverter.GetBytes(@short), DataType.Short),
+				ushort @ushort => EncodePrimitiveType(BitConverter.GetBytes(@ushort), DataType.UShort),
+				int @int => EncodePrimitiveType(BitConverter.GetBytes(@int), DataType.Int),
+				uint @uint => EncodePrimitiveType(BitConverter.GetBytes(@uint), DataType.UInt),
+				float @float => EncodePrimitiveType(BitConverter.GetBytes(@float), DataType.Float),
+				long @long => EncodePrimitiveType(BitConverter.GetBytes(@long), DataType.Long),
+				ulong @ulong => EncodePrimitiveType(BitConverter.GetBytes(@ulong), DataType.ULong),
+				double @double => EncodePrimitiveType(BitConverter.GetBytes(@double), DataType.Double),
+				char @char => EncodeDynamicType(BitConverter.GetBytes(@char), DataType.Char),
+				string @string => EncodeDynamicType(Encoding.UTF8.GetBytes(@string), DataType.String),
+				_ => throw new ArgumentOutOfRangeException($"{nameof(entry.Value)}", $"Unrecognized type to be encoded to memory stream: {entry.Value}")
+
+			};
+			return (ushort)encoded.Length;
+
+			byte[] EncodeDynamicType(byte[] bytes, DataType dataType)
+			{
+				if (bytes == null) throw new ArgumentNullException(nameof(bytes));
+				var encode = new byte[KeySize + TypeSize + this.DynamicTypeSize + bytes.Length];
+				encode[index] = (byte)entry.Key; // ToDo abstract hard size
+				encode[index += KeySize] = (byte)dataType;
+				var dynamicSize = BitConverter.GetBytes((ushort)bytes.Length);
+				Array.Copy(dynamicSize, 0, encode, index += TypeSize, dynamicSize.Length);
+				Array.Copy(bytes, 0, encode, index + dynamicSize.Length, bytes.Length);
+				return encode;
+			}
+
+			byte[] EncodePrimitiveType(byte[] bytes, DataType dataType)
+			{
+				if (bytes == null) throw new ArgumentNullException(nameof(bytes));
+				var encode = new byte[KeySize + TypeSize + bytes.Length];
+				encode[index] = (byte)entry.Key; // ToDo abstract hard size
+				encode[index += KeySize] = (byte)dataType;
+				Array.Copy(bytes, 0, encode, index + TypeSize, bytes.Length);
+				return encode;
+			}
+		}
+
+		/// <summary>
+		/// Decode data stream
+		/// </summary>
+		/// <param name="data"> Data to decode </param>
+		/// <param name="count"> running count of individual data chunks in data stream </param>
+		/// <returns> Individual data chunk value </returns>
+		/// <exception cref="ArgumentNullException"> Thrown when <see cref="data"/> is null. </exception>
+		/// <exception cref="ArgumentOutOfRangeException"> Thrown value read from memory stream is not a known data type <see cref="DataType"/>. </exception>
+		protected object Decode(byte[] data, ref object count)
+		{
+			if (data == null) throw new ArgumentNullException(nameof(data));
+			var i = (ushort)count;
+			var type = (DataType)data[i += KeySize];
+
+			i += TypeSize; // move to data
+			var decoded = type switch
+			{
+				DataType.ByteArray => ByteArrayType(),
+				DataType.Byte => new object[] { data[i], sizeof(byte) },
+				DataType.SByte => new object[] { unchecked((sbyte)data[i]), sizeof(sbyte) },
+				DataType.Bool => new object[] { BitConverter.ToBoolean(data, i), sizeof(bool) },
+				DataType.Short => new object[] { BitConverter.ToInt16(data, i), sizeof(short) },
+				DataType.UShort => new object[] { BitConverter.ToUInt16(data, i), sizeof(ushort) },
+				DataType.Int => new object[] { BitConverter.ToInt32(data, i), sizeof(int) },
+				DataType.UInt => new object[] { BitConverter.ToUInt32(data, i), sizeof(uint) },
+				DataType.Float => new object[] { BitConverter.ToSingle(data, i), sizeof(float) },
+				DataType.Long => new object[] { BitConverter.ToInt64(data, i), sizeof(long) },
+				DataType.ULong => new object[] { BitConverter.ToUInt64(data, i), sizeof(ulong) },
+				DataType.Double => new object[] { BitConverter.ToDouble(data, i), sizeof(double) },
+				DataType.Char => new object[] { BitConverter.ToChar(data, i += this.DynamicTypeSize), sizeof(char) },
+				DataType.String => StringType(),
+				_ => throw new ArgumentOutOfRangeException($"{nameof(data)}", $"Unrecognized type decoded in memory stream: {type}")
+
+			};
+
+			var value = decoded[0];
+			i += (ushort)((int)(decoded[1])); // move to end
+
+			count = i;
+			return value;
+
+			object[] ByteArrayType()
+			{
+				int dynamicTypeCount = BitConverter.ToUInt16(data, i);
+				value = new byte[dynamicTypeCount];
+				Array.Copy(data, i += this.DynamicTypeSize, (byte[])value, 0, dynamicTypeCount);
+				return new[] { value, dynamicTypeCount };
+			}
+
+			object[] StringType()
+			{
+				int dynamicTypeCount = BitConverter.ToUInt16(data, i);
+				return new object[] { Encoding.UTF8.GetString(data, i += this.DynamicTypeSize, dynamicTypeCount), dynamicTypeCount };
+			}
+		}
+
+		/// <summary> Header for printable memory dump </summary>
+		/// <remarks> For debugging </remarks>
+		/// <returns> Header for printable memory dump </returns>
+		protected static StringBuilder Dump()
+		{
+			var sb = new StringBuilder(32);
+			sb.Append("     ");
+			for (var i = 0; i < 32; i++)
+				sb.Append($"{i,0x03} ");
+			sb.AppendLine();
+			sb.Append("     ");
+			for (var i = 0; i < 32; i++)
+				sb.Append("----");
+			Debug.WriteLine(sb.ToString());
+			sb.Clear();
+			return sb;
+		}
+	}
+}

--- a/MemoryManager/GHIElectronics.TinyCLR.Drivers.MemoryManager/MemoryManager.cs
+++ b/MemoryManager/GHIElectronics.TinyCLR.Drivers.MemoryManager/MemoryManager.cs
@@ -1,0 +1,90 @@
+using System;
+
+// ReSharper disable InconsistentNaming
+// ReSharper disable ArrangeThisQualifier
+#pragma warning disable IDE1006 // Naming Styles
+#pragma warning disable IDE0009 // Member access should be qualified.
+
+
+namespace GHIElectronics.TinyCLR.Drivers.MemoryManager
+{
+	public class MemoryManager
+	{
+		private readonly IMemoryInterface _memoryInterface;
+
+		/// <summary>
+		/// Instantiate a new copy of the <see cref="MemoryManager"/>
+		/// </summary>
+		/// <param name="memoryInterface"></param>
+		public MemoryManager(IMemoryInterface memoryInterface) => _memoryInterface = memoryInterface;
+
+		/// <summary>
+		/// Recall a value
+		/// </summary>
+		/// <param name="key"> Item to recall </param>
+		/// <param name="value"> Value of item </param>
+		/// <returns> True if item was found </returns>
+		public bool Recall(byte key, out object value)
+		{
+			value = null;
+			var data = this._memoryInterface.Deserialize(out _);
+			if (data.Contains(key))
+			{
+				value = data[key];
+				return true;
+			}
+
+			return false;
+		}
+
+		/// <summary>
+		/// Adds or Replaces a value in the secure memory manager
+		/// </summary>
+		/// <param name="key"> Item to remove or replace </param>
+		/// <param name="value"> Value of item </param>
+		/// <returns> True if item was added or replaced </returns>
+		/// <exception cref="ArgumentNullException"> Thrown when <see cref="value"/> is null </exception>
+		public bool AddOrReplace(byte key, object value)
+		{
+			if (value is null)
+				throw new ArgumentNullException(nameof(value));
+
+			var data = this._memoryInterface.Deserialize(out _);
+			if (data.Contains(key))
+				data.Remove(key);
+
+			data.Add(key, value);
+			return this._memoryInterface.Serialize(data);
+		}
+
+		/// <summary>
+		/// Remove a value from the secure memory manager
+		/// </summary>
+		/// <param name="key"> Item to remove </param>
+		/// <returns> True if item was found and removed </returns>
+		public bool Remove(byte key)
+		{
+			var data = this._memoryInterface.Deserialize(out _);
+			if (data.Contains(key))
+			{
+				data.Remove(key);
+				if (this._memoryInterface.Serialize(data))
+					return true;
+			}
+
+			return false;
+		}
+
+		/// <summary>
+		/// Retrieve the size of free memory
+		/// </summary>
+		/// <returns> Free memory in bytes</returns>
+		public uint Free()
+		{
+			this._memoryInterface.Deserialize(out var used);
+			return this._memoryInterface.Size - used;
+		}
+
+		public void Dump() => this._memoryInterface.Dump();
+	}
+}

--- a/MemoryManager/GHIElectronics.TinyCLR.Drivers.MemoryManager/MemoryManager.cs
+++ b/MemoryManager/GHIElectronics.TinyCLR.Drivers.MemoryManager/MemoryManager.cs
@@ -13,15 +13,11 @@ namespace GHIElectronics.TinyCLR.Drivers.MemoryManager
     {
         private readonly IMemoryInterface _memoryInterface;
 
-        /// <summary>
-        /// Instantiate a new copy of the <see cref="MemoryManager"/>
-        /// </summary>
+        /// <summary> Instantiate a new copy of the <see cref="MemoryManager"/> </summary>
         /// <param name="memoryInterface"></param>
         public MemoryManager(IMemoryInterface memoryInterface) => _memoryInterface = memoryInterface;
 
-        /// <summary>
-        /// Recall a value
-        /// </summary>
+        /// <summary> Recall a value </summary>
         /// <param name="key"> Item to recall </param>
         /// <param name="value"> Value of item </param>
         /// <returns> True if item was found </returns>
@@ -37,9 +33,7 @@ namespace GHIElectronics.TinyCLR.Drivers.MemoryManager
             return false;
         }
 
-        /// <summary>
-        /// Adds or Replaces a value in the secure memory manager
-        /// </summary>
+        /// <summary> Adds or Replaces a value in the secure memory manager </summary>
         /// <param name="key"> Item to remove or replace </param>
         /// <param name="value"> Value of item </param>
         /// <returns> True if item was added or replaced </returns>
@@ -56,9 +50,7 @@ namespace GHIElectronics.TinyCLR.Drivers.MemoryManager
             return _memoryInterface.Serialize(data);
         }
 
-        /// <summary>
-        /// Remove a value from the secure memory manager
-        /// </summary>
+        /// <summary> Remove a value from the secure memory manager </summary>
         /// <param name="key"> Item to remove </param>
         /// <returns> True if item was found and removed </returns>
         public bool Remove(byte key)
@@ -73,9 +65,7 @@ namespace GHIElectronics.TinyCLR.Drivers.MemoryManager
             return false;
         }
 
-        /// <summary>
-        /// Retrieve the size of free memory
-        /// </summary>
+        /// <summary> Retrieve the size of free memory </summary>
         /// <returns> Free memory in bytes</returns>
         public uint Free()
         {

--- a/MemoryManager/GHIElectronics.TinyCLR.Drivers.MemoryManager/Properties/AssemblyInfo.cs
+++ b/MemoryManager/GHIElectronics.TinyCLR.Drivers.MemoryManager/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("GHIElectronics.TinyCLR.Drivers.MemoryManager")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("GHIElectronics.TinyCLR.Drivers.MemoryManager")]
+[assembly: AssemblyCopyright("Copyright ©  2021")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("d21b4747-8955-4d13-ac38-8f7c6840f5ed")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/MemoryManager/GHIElectronics.TinyCLR.Drivers.MemoryManager/RtcMemory/RtcMemoryInterface.cs
+++ b/MemoryManager/GHIElectronics.TinyCLR.Drivers.MemoryManager/RtcMemory/RtcMemoryInterface.cs
@@ -1,0 +1,242 @@
+using System;
+using System.Collections;
+using System.Diagnostics;
+
+using GHIElectronics.TinyCLR.Devices.Rtc;
+
+// ReSharper disable InconsistentNaming
+// ReSharper disable ArrangeThisQualifier
+#pragma warning disable IDE1006 // Naming Styles
+#pragma warning disable IDE0009 // Member access should be qualified.
+
+
+namespace GHIElectronics.TinyCLR.Drivers.MemoryManager.RtcMemory
+{
+	public class RtcMemoryInterface : MemoryInterfaceBase, IMemoryInterface
+	{
+		private readonly RtcController _rtcControllerProvider;
+		private int _dataPointer = -1;
+
+		public RtcMemoryInterface(RtcController rtcControllerProvider)
+		{
+			this._rtcControllerProvider = rtcControllerProvider;
+
+			if (((IMemoryInterface)this).Size > ushort.MaxValue)
+				DataCountSize = DynamicTypeSize = sizeof(uint);
+		}
+
+		#region Implementation of IMemoryInterface
+
+		uint IMemoryInterface.Size => this._rtcControllerProvider.BackupMemorySize;
+
+		/// <summary>
+		/// Get structure of available data
+		/// </summary>
+		/// <returns> Structure of available data</returns>
+		/// <exception cref="InvalidOperationException"> Thrown when a block of memory can't be read. </exception>
+		Hashtable IMemoryInterface.Deserialize(out uint usedMemory)
+		{
+			var data = new Hashtable();
+			object count = (ushort)0;
+
+			if (this._dataPointer >= 0)
+			{
+				if (this.Read(this._dataPointer, out var dataBuffer))
+				{
+					while ((ushort)count < dataBuffer.Length)
+						data.Add(dataBuffer[(ushort)count], this.Decode(dataBuffer, ref count));
+
+					usedMemory = (ushort)count > 0 ? (uint)(this.DataCountSize + dataBuffer.Length + CrcSize) : 0;
+					return data;
+				}
+			}
+
+			this._dataPointer = -1;
+			usedMemory = 0;
+			return data;
+		}
+
+		/// <summary>
+		/// Serialize and write to memory
+		/// </summary>
+		/// <param name="data"> Data structure to serialize </param>
+		/// <returns> True if resulting <see cref="data"/> was serialized and written to memory</returns>
+		bool IMemoryInterface.Serialize(Hashtable data)
+		{
+			ushort dataSize = 0;
+			var values = new ArrayList();
+			foreach (DictionaryEntry entry in data)
+			{
+				dataSize += this.Encode(entry, out var output);
+				values.Add(output);
+			}
+
+			// empty
+			if (data.Count == 0)
+			{
+				this._dataPointer = -1;
+				return true;
+			}
+
+			int headerSize = this.DataCountSize;
+			var payloadSize = dataSize + CrcSize;
+			var totalSize = headerSize + payloadSize;
+
+			// too large for memory
+			if (totalSize > ((IMemoryInterface)this).Size)
+				return false;
+
+			var encoded = new byte[totalSize];
+			var count = BitConverter.GetBytes(payloadSize);
+			Array.Copy(count, 0, encoded, 0, count.Length);
+
+			var runningDataCount = headerSize;
+			foreach (var value in values)
+			{
+				var bytes = (byte[])value;
+				Array.Copy(bytes, 0, encoded, runningDataCount, bytes.Length);
+				runningDataCount += bytes.Length;
+			}
+
+			this.Crc.Reset();
+			var crc = BitConverter.GetBytes(this.Crc.ComputeHash(encoded, headerSize, dataSize));
+			Array.Copy(crc, 0, encoded, encoded.Length - CrcSize, crc.Length);
+
+			return this.Write(encoded);
+		}
+
+		/// <summary> Get entire memory area </summary>
+		/// <remarks> For debugging </remarks>
+		/// <returns> Entire memory area</returns>
+		void IMemoryInterface.Dump()
+		{
+			var sb = Dump();
+
+			var block = new byte[32];
+			for (uint i = 0; i < this._rtcControllerProvider.BackupMemorySize / 32; i++) {
+				this._rtcControllerProvider.ReadBackupMemory(block, 0, i * 32, 32);
+				sb.Append($"{i,0x03:x2}| ");
+				for (var @byte = 0; @byte < 32; @byte++)
+					sb.Append($"{block[@byte],0x03:x2} ");
+				sb.AppendLine();
+			}
+
+			Debug.WriteLine(sb.ToString());
+		}
+
+		#endregion Implementation of IMemoryInterface
+
+		///  <summary>
+		///  Return only data from full frame
+		///  </summary>
+		/// <remarks> Points to frame start </remarks>
+		///  <param name="index"> Index of start of data frame in overall memory map </param>
+		///  <param name="data"></param>
+		///  <returns> True if memory is read successfully </returns>
+		private bool Read(int index, out byte[] data)
+		{
+			data = new byte[0];
+
+			// test bounds
+			if (index >= ((IMemoryInterface)this).Size)
+				index = 0;
+
+			// gather/check count
+			if (!this.Gather(out var countGather, this.DataCountSize, ref index))
+				return false;
+
+			var dataCount = BitConverter.ToUInt16(countGather, 0);
+			if (dataCount > ((IMemoryInterface)this).Size - this.DataCountSize)
+				return false;
+
+			if (dataCount <= 0)
+				return true;
+
+			// gather/check data
+			if (!this.Gather(out var gathered, dataCount, ref index))
+				return false;
+
+			var dataSize = gathered.Length - CrcSize;
+			data = new byte[dataSize];
+			Array.Copy(gathered, 0, data, 0, data.Length);
+
+			this.Crc.Reset();
+			return this.Crc.ComputeHash(gathered, 0, dataSize) == BitConverter.ToUInt16(gathered, dataSize);
+		}
+
+		private bool Gather(out byte[] gathered, int count, ref int index)
+		{
+			gathered = new byte[count];
+			var destinationOffset = 0;
+			while (count > 0)
+			{
+				var remainingBlockLength = (int)(((IMemoryInterface)this).Size - index);
+				var readLength = count < remainingBlockLength ? count : remainingBlockLength;
+
+				if (this._rtcControllerProvider.ReadBackupMemory(gathered, (uint)destinationOffset, (uint)index, readLength) != readLength)
+					return false;
+
+				if ((index += readLength) >= ((IMemoryInterface)this).Size)
+					index = 0;
+				destinationOffset += readLength;
+				count -= readLength;
+			}
+
+			return true;
+		}
+
+		/// <summary>
+		/// Write data full frame to memory, with as many redundant copies as specified <para/>
+		/// </summary>
+		/// <param name="data"> Full data frame </param>
+		/// <returns> True if data was verified to be written at least once </returns>
+		/// <exception cref="InvalidOperationException"> Thrown when a block of memory cant be read. </exception>
+		/// <remarks> Memory read in order to find end of data </remarks>
+		private bool Write(byte[] data, int index = -1)
+		{
+			if (data == null) throw new ArgumentNullException(nameof(data));
+			index = index < 0 ? new Random().Next((int)((IMemoryInterface)this).Size): index;
+			var temp = index;
+
+			// write and validate
+			if (this.CoreWrite(data, index) && this.Read(index, out _))
+			{
+				this._dataPointer = temp;
+				return true;
+			}
+
+			// debug
+			//var error = new byte[] { 0xee };
+			//_rtcControllerProvider.WriteBackupMemory(error, ?);
+
+			return false;
+		}
+
+		/// <summary> Write Expects 1 full frame (Count+Data+Crc) to memory </summary>
+		/// <param name="data"> Full or partial block of memory to write</param>
+		/// <param name="index"> Start index </param>
+		/// <remarks> Wraps. No offsets. </remarks>
+		private bool CoreWrite(byte[] data, int index)
+		{
+			if (data == null) throw new ArgumentNullException(nameof(data));
+			var remainingLength = data.Length;
+			var count = 0;
+
+			while (remainingLength > 0)
+			{
+				var remainingBlockLength = (int)(((IMemoryInterface)this).Size - index);
+				var writeLength = remainingLength < remainingBlockLength ? remainingLength : remainingBlockLength;
+
+				this._rtcControllerProvider.WriteBackupMemory(data, (uint)count, (uint)index, writeLength);
+
+				// update indices
+				if ((index += writeLength) >= ((IMemoryInterface)this).Size)
+					index = 0;
+				count += writeLength;
+				remainingLength -= writeLength;
+			}
+
+			return data.Length == count;
+		}
+	}
+}

--- a/MemoryManager/GHIElectronics.TinyCLR.Drivers.MemoryManager/RtcMemory/RtcMemoryInterface.cs
+++ b/MemoryManager/GHIElectronics.TinyCLR.Drivers.MemoryManager/RtcMemory/RtcMemoryInterface.cs
@@ -1,9 +1,10 @@
 using System;
 using System.Collections;
 using System.Diagnostics;
-
+using System.Text;
 using GHIElectronics.TinyCLR.Devices.Rtc;
 
+// ReSharper disable TooWideLocalVariableScope
 // ReSharper disable InconsistentNaming
 // ReSharper disable ArrangeThisQualifier
 #pragma warning disable IDE1006 // Naming Styles
@@ -12,231 +13,238 @@ using GHIElectronics.TinyCLR.Devices.Rtc;
 
 namespace GHIElectronics.TinyCLR.Drivers.MemoryManager.RtcMemory
 {
-	public class RtcMemoryInterface : MemoryInterfaceBase, IMemoryInterface
-	{
-		private readonly RtcController _rtcControllerProvider;
-		private int _dataPointer = -1;
+    public class RtcMemoryInterface : MemoryInterfaceBase, IMemoryInterface
+    {
+        private readonly RtcController _rtcControllerProvider;
+        private int _dataPointer = -1;
 
-		public RtcMemoryInterface(RtcController rtcControllerProvider)
-		{
-			this._rtcControllerProvider = rtcControllerProvider;
+        public RtcMemoryInterface(RtcController rtcControllerProvider)
+        {
+            _rtcControllerProvider = rtcControllerProvider;
 
-			if (((IMemoryInterface)this).Size > ushort.MaxValue)
-				DataCountSize = DynamicTypeSize = sizeof(uint);
-		}
+            if (((IMemoryInterface)this).Size > ushort.MaxValue)
+                DataCountSize = DynamicTypeSize = sizeof(uint);
+        }
 
-		#region Implementation of IMemoryInterface
+        #region Implementation of IMemoryInterface
 
-		uint IMemoryInterface.Size => this._rtcControllerProvider.BackupMemorySize;
+        uint IMemoryInterface.Size => _rtcControllerProvider.BackupMemorySize;
 
-		/// <summary>
-		/// Get structure of available data
-		/// </summary>
-		/// <returns> Structure of available data</returns>
-		/// <exception cref="InvalidOperationException"> Thrown when a block of memory can't be read. </exception>
-		Hashtable IMemoryInterface.Deserialize(out uint usedMemory)
-		{
-			var data = new Hashtable();
-			object count = (ushort)0;
+        /// <summary>
+        /// Get structure of available data
+        /// </summary>
+        /// <returns> Structure of available data</returns>
+        bool IMemoryInterface.Deserialize(out Hashtable data, out uint usedMemory)
+        {
+            data = new Hashtable();
+            object count = (ushort)0;
+            usedMemory = 0;
 
-			if (this._dataPointer >= 0)
-			{
-				if (this.Read(this._dataPointer, out var dataBuffer))
-				{
-					while ((ushort)count < dataBuffer.Length)
-						data.Add(dataBuffer[(ushort)count], this.Decode(dataBuffer, ref count));
+            if (_dataPointer >= 0)
+            {
+                if (!Read(_dataPointer, out var dataBuffer))
+                    return false;
 
-					usedMemory = (ushort)count > 0 ? (uint)(this.DataCountSize + dataBuffer.Length + CrcSize) : 0;
-					return data;
-				}
-			}
+                while ((ushort)count < dataBuffer.Length)
+                    data.Add(dataBuffer[(ushort)count], Decode(dataBuffer, ref count));
 
-			this._dataPointer = -1;
-			usedMemory = 0;
-			return data;
-		}
+                usedMemory = (ushort)count > 0 ? (uint)(DataCountSize + dataBuffer.Length + CrcSize) : 0;
+            }
 
-		/// <summary>
-		/// Serialize and write to memory
-		/// </summary>
-		/// <param name="data"> Data structure to serialize </param>
-		/// <returns> True if resulting <see cref="data"/> was serialized and written to memory</returns>
-		bool IMemoryInterface.Serialize(Hashtable data)
-		{
-			ushort dataSize = 0;
-			var values = new ArrayList();
-			foreach (DictionaryEntry entry in data)
-			{
-				dataSize += this.Encode(entry, out var output);
-				values.Add(output);
-			}
+            return true;
+        }
 
-			// empty
-			if (data.Count == 0)
-			{
-				this._dataPointer = -1;
-				return true;
-			}
+        /// <summary>
+        /// Serialize and write to memory
+        /// </summary>
+        /// <param name="data"> Data structure to serialize </param>
+        /// <returns> True if resulting <see cref="data"/> was serialized and written to memory</returns>
+        bool IMemoryInterface.Serialize(Hashtable data)
+        {
+            ushort dataSize = 0;
+            var values = new ArrayList();
+            foreach (DictionaryEntry entry in data)
+            {
+                dataSize += Encode(entry, out var output);
+                values.Add(output);
+            }
 
-			int headerSize = this.DataCountSize;
-			var payloadSize = dataSize + CrcSize;
-			var totalSize = headerSize + payloadSize;
+            // empty
+            if (data.Count == 0)
+            {
+                _dataPointer = -1;
+                return true;
+            }
 
-			// too large for memory
-			if (totalSize > ((IMemoryInterface)this).Size)
-				return false;
+            int headerSize = DataCountSize;
+            var payloadSize = dataSize + CrcSize;
+            var totalSize = headerSize + payloadSize;
 
-			var encoded = new byte[totalSize];
-			var count = BitConverter.GetBytes(payloadSize);
-			Array.Copy(count, 0, encoded, 0, count.Length);
+            // too large for memory
+            if (totalSize > ((IMemoryInterface)this).Size)
+                return false;
 
-			var runningDataCount = headerSize;
-			foreach (var value in values)
-			{
-				var bytes = (byte[])value;
-				Array.Copy(bytes, 0, encoded, runningDataCount, bytes.Length);
-				runningDataCount += bytes.Length;
-			}
+            var encoded = new byte[totalSize];
+            var count = BitConverter.GetBytes(payloadSize);
+            Array.Copy(count, 0, encoded, 0, count.Length);
 
-			this.Crc.Reset();
-			var crc = BitConverter.GetBytes(this.Crc.ComputeHash(encoded, headerSize, dataSize));
-			Array.Copy(crc, 0, encoded, encoded.Length - CrcSize, crc.Length);
+            var runningDataCount = headerSize;
 
-			return this.Write(encoded);
-		}
+            // optimize by moving outside of loop (interpreter will not do this)
+            byte[] bytes;
 
-		/// <summary> Get entire memory area </summary>
-		/// <remarks> For debugging </remarks>
-		/// <returns> Entire memory area</returns>
-		void IMemoryInterface.Dump()
-		{
-			var sb = Dump();
+            foreach (var value in values)
+            {
+                bytes = (byte[])value;
+                Array.Copy(bytes, 0, encoded, runningDataCount, bytes.Length);
+                runningDataCount += bytes.Length;
+            }
 
-			var block = new byte[32];
-			for (uint i = 0; i < this._rtcControllerProvider.BackupMemorySize / 32; i++) {
-				this._rtcControllerProvider.ReadBackupMemory(block, 0, i * 32, 32);
-				sb.Append($"{i,0x03:x2}| ");
-				for (var @byte = 0; @byte < 32; @byte++)
-					sb.Append($"{block[@byte],0x03:x2} ");
-				sb.AppendLine();
-			}
+            Crc.Reset();
+            var crc = BitConverter.GetBytes(Crc.ComputeHash(encoded, headerSize, dataSize));
+            Array.Copy(crc, 0, encoded, encoded.Length - CrcSize, crc.Length);
 
-			Debug.WriteLine(sb.ToString());
-		}
+            return Write(encoded);
+        }
 
-		#endregion Implementation of IMemoryInterface
+        /// <summary> See entire memory area </summary>
+        /// <remarks> For debugging </remarks>
+        void IMemoryInterface.Dump(StringBuilder sb)
+        {
+            sb = Dump(sb);
+            var block = new byte[32];
+            for (uint i = 0; i < _rtcControllerProvider.BackupMemorySize / 32; i++)
+            {
+                _rtcControllerProvider.ReadBackupMemory(block, 0, i * 32, 32);
+                sb.Append($"{i,0x03:x2}| ");
+                for (var @byte = 0; @byte < 32; @byte++)
+                    sb.Append($"{block[@byte],0x03:x2} ");
+                sb.AppendLine();
+            }
 
-		///  <summary>
-		///  Return only data from full frame
-		///  </summary>
-		/// <remarks> Points to frame start </remarks>
-		///  <param name="index"> Index of start of data frame in overall memory map </param>
-		///  <param name="data"></param>
-		///  <returns> True if memory is read successfully </returns>
-		private bool Read(int index, out byte[] data)
-		{
-			data = new byte[0];
+            Debug.WriteLine(sb.ToString());
+        }
 
-			// test bounds
-			if (index >= ((IMemoryInterface)this).Size)
-				index = 0;
+        #endregion Implementation of IMemoryInterface
 
-			// gather/check count
-			if (!this.Gather(out var countGather, this.DataCountSize, ref index))
-				return false;
+        ///  <summary>
+        ///  Return only data from full frame
+        ///  </summary>
+        /// <remarks> Points to frame start </remarks>
+        ///  <param name="index"> Index of start of data frame in overall memory </param>
+        ///  <param name="data"> Read memory </param>
+        ///  <returns> True if memory is read successfully </returns>
+        private bool Read(int index, out byte[] data)
+        {
+            data = new byte[0];
 
-			var dataCount = BitConverter.ToUInt16(countGather, 0);
-			if (dataCount > ((IMemoryInterface)this).Size - this.DataCountSize)
-				return false;
+            // test bounds
+            var size = ((IMemoryInterface)this).Size;
+            if (index >= size)
+                index = 0;
 
-			if (dataCount <= 0)
-				return true;
+            // gather/check count
+            if (!CoreRead(out var countGather, DataCountSize, ref index))
+                return false;
 
-			// gather/check data
-			if (!this.Gather(out var gathered, dataCount, ref index))
-				return false;
+            var dataCount = BitConverter.ToUInt16(countGather, 0);
+            if (dataCount > size - DataCountSize)
+                return false;
 
-			var dataSize = gathered.Length - CrcSize;
-			data = new byte[dataSize];
-			Array.Copy(gathered, 0, data, 0, data.Length);
+            if (dataCount <= 0)
+                return true;
 
-			this.Crc.Reset();
-			return this.Crc.ComputeHash(gathered, 0, dataSize) == BitConverter.ToUInt16(gathered, dataSize);
-		}
+            // gather/check data
+            if (!CoreRead(out var gathered, dataCount, ref index))
+                return false;
 
-		private bool Gather(out byte[] gathered, int count, ref int index)
-		{
-			gathered = new byte[count];
-			var destinationOffset = 0;
-			while (count > 0)
-			{
-				var remainingBlockLength = (int)(((IMemoryInterface)this).Size - index);
-				var readLength = count < remainingBlockLength ? count : remainingBlockLength;
+            var dataSize = gathered.Length - CrcSize;
+            data = new byte[dataSize];
+            Array.Copy(gathered, 0, data, 0, data.Length);
 
-				if (this._rtcControllerProvider.ReadBackupMemory(gathered, (uint)destinationOffset, (uint)index, readLength) != readLength)
-					return false;
+            Crc.Reset();
+            return Crc.ComputeHash(gathered, 0, dataSize) == BitConverter.ToUInt16(gathered, dataSize);
+        }
 
-				if ((index += readLength) >= ((IMemoryInterface)this).Size)
-					index = 0;
-				destinationOffset += readLength;
-				count -= readLength;
-			}
+        private bool CoreRead(out byte[] gathered, int count, ref int index)
+        {
+            gathered = new byte[count];
+            var destinationOffset = 0;
 
-			return true;
-		}
+            // optimize by moving outside of loop (interpreter will not do this)
+            int remainingBlockLength;
+            int readLength;
+            var size = ((IMemoryInterface)this).Size;
 
-		/// <summary>
-		/// Write data full frame to memory, with as many redundant copies as specified <para/>
-		/// </summary>
-		/// <param name="data"> Full data frame </param>
-		/// <returns> True if data was verified to be written at least once </returns>
-		/// <exception cref="InvalidOperationException"> Thrown when a block of memory cant be read. </exception>
-		/// <remarks> Memory read in order to find end of data </remarks>
-		private bool Write(byte[] data, int index = -1)
-		{
-			if (data == null) throw new ArgumentNullException(nameof(data));
-			index = index < 0 ? new Random().Next((int)((IMemoryInterface)this).Size): index;
-			var temp = index;
+            while (count > 0)
+            {
+                remainingBlockLength = (int)(size - index);
+                readLength = count < remainingBlockLength ? count : remainingBlockLength;
 
-			// write and validate
-			if (this.CoreWrite(data, index) && this.Read(index, out _))
-			{
-				this._dataPointer = temp;
-				return true;
-			}
+                if (_rtcControllerProvider.ReadBackupMemory(gathered, (uint)destinationOffset, (uint)index, readLength) != readLength)
+                    return false;
 
-			// debug
-			//var error = new byte[] { 0xee };
-			//_rtcControllerProvider.WriteBackupMemory(error, ?);
+                if ((index += readLength) >= size)
+                    index = 0;
+                destinationOffset += readLength;
+                count -= readLength;
+            }
 
-			return false;
-		}
+            return true;
+        }
 
-		/// <summary> Write Expects 1 full frame (Count+Data+Crc) to memory </summary>
-		/// <param name="data"> Full or partial block of memory to write</param>
-		/// <param name="index"> Start index </param>
-		/// <remarks> Wraps. No offsets. </remarks>
-		private bool CoreWrite(byte[] data, int index)
-		{
-			if (data == null) throw new ArgumentNullException(nameof(data));
-			var remainingLength = data.Length;
-			var count = 0;
+        /// <summary>
+        /// Write data to memory <para/>
+        /// </summary>
+        /// <param name="data"> Full data frame </param>
+        /// <param name="index"> Optional index to begin write </param>
+        /// <returns> True if data was verified to be written </returns>
+        /// <exception cref="ArgumentNullException"> Thrown if <see cref="data"/> is null </exception>
+        private bool Write(byte[] data, int index = -1)
+        {
+            if (data == null) throw new ArgumentNullException(nameof(data));
 
-			while (remainingLength > 0)
-			{
-				var remainingBlockLength = (int)(((IMemoryInterface)this).Size - index);
-				var writeLength = remainingLength < remainingBlockLength ? remainingLength : remainingBlockLength;
+            var size = ((IMemoryInterface)this).Size;
+            index = index < 0 || index >= size ? new Random().Next((int)size) : index;
+            var temp = index;
 
-				this._rtcControllerProvider.WriteBackupMemory(data, (uint)count, (uint)index, writeLength);
+            // write and validate
+            if (!CoreWrite(data, index) || !Read(index, out _))
+                return false;
 
-				// update indices
-				if ((index += writeLength) >= ((IMemoryInterface)this).Size)
-					index = 0;
-				count += writeLength;
-				remainingLength -= writeLength;
-			}
+            _dataPointer = temp;
+            return true;
+        }
 
-			return data.Length == count;
-		}
-	}
+        /// <summary> Write Expects 1 full frame (Count+Data+Crc) to memory </summary>
+        /// <param name="data"> Full or partial block of memory to write </param>
+        /// <param name="index"> Start index </param>
+        private bool CoreWrite(byte[] data, int index)
+        {
+            if (data == null) throw new ArgumentNullException(nameof(data));
+            var remainingLength = data.Length;
+            var count = 0;
+
+            // optimize by moving outside of loop (interpreter will not do this)
+            int remainingBlockLength;
+            int writeLength;
+            var size = ((IMemoryInterface)this).Size;
+
+            while (remainingLength > 0)
+            {
+                remainingBlockLength = (int)(size - index);
+                writeLength = remainingLength < remainingBlockLength ? remainingLength : remainingBlockLength;
+
+                _rtcControllerProvider.WriteBackupMemory(data, (uint)count, (uint)index, writeLength);
+
+                // update indices
+                if ((index += writeLength) >= size)
+                    index = 0;
+                count += writeLength;
+                remainingLength -= writeLength;
+            }
+
+            return data.Length == count;
+        }
+    }
 }

--- a/MemoryManager/GHIElectronics.TinyCLR.Drivers.MemoryManager/SecureMemory/SecureStorageInterface.cs
+++ b/MemoryManager/GHIElectronics.TinyCLR.Drivers.MemoryManager/SecureMemory/SecureStorageInterface.cs
@@ -1,0 +1,301 @@
+using System;
+using System.Collections;
+using System.Diagnostics;
+using GHIElectronics.TinyCLR.Devices.SecureStorage;
+
+// ReSharper disable InconsistentNaming
+// ReSharper disable ArrangeThisQualifier
+#pragma warning disable IDE1006 // Naming Styles
+#pragma warning disable IDE0009 // Member access should be qualified.
+
+
+namespace GHIElectronics.TinyCLR.Drivers.MemoryManager.SecureMemory
+{
+    public class SecureStorageInterface : MemoryInterfaceBase, IMemoryInterface {
+        private readonly uint _blockCount;
+        private readonly SecureStorageController _secureStorageController;
+
+        public SecureStorageInterface(SecureStorageController secureStorageController) {
+            _secureStorageController = secureStorageController;
+            _blockCount = _secureStorageController.TotalSize / _secureStorageController.BlockSize; // 256
+
+            if (((IMemoryInterface)this).Size > ushort.MaxValue)
+                DataCountSize = DynamicTypeSize = sizeof(uint);
+        }
+
+        #region Implementation of IMemoryInterface
+
+        uint IMemoryInterface.Size => _secureStorageController.TotalSize;
+
+        /// <summary>
+        /// Get structure of available data
+        /// </summary>
+        /// <returns> Structure of available data</returns>
+        /// <exception cref="InvalidOperationException"> Thrown when a block of memory can't be read. </exception>
+        Hashtable IMemoryInterface.Deserialize(out uint usedMemory) {
+            var data = new Hashtable();
+            object count = (ushort)0;
+
+            // seek data
+            for (var blockIndex = (int)(_blockCount - 1); blockIndex >= 0; blockIndex--) // 255 -> 0
+            {
+                var read = new byte[_secureStorageController.BlockSize];
+
+                // bad block
+                if (_secureStorageController.Read((uint)blockIndex, read) != _secureStorageController.BlockSize)
+                    throw new InvalidOperationException($"{nameof(IMemoryInterface.Deserialize)} platform read failed"); // ToDo? retry? throw? move on?
+
+                if (BitConverter.ToUInt16(Sentinel, 0) == BitConverter.ToUInt16(read, 0) && Read((int)(blockIndex * _secureStorageController.BlockSize), out var dataBuffer)) {
+                    while ((ushort)count < dataBuffer.Length)
+                        data.Add(dataBuffer[(ushort)count], Decode(dataBuffer, ref count));
+
+                    usedMemory = (ushort)count > 0 ? (uint)(Sentinel.Length + DataCountSize + dataBuffer.Length + CrcSize) : 0;
+                    return data;
+                }
+            }
+
+            usedMemory = (ushort)count;
+            return data;
+        }
+
+        /// <summary>
+        /// Serialize and write to memory
+        /// </summary>
+        /// <param name="data"> Data structure to serialize </param>
+        /// <returns> True if resulting <see cref="data"/> was serialized and written to memory</returns>
+        bool IMemoryInterface.Serialize(Hashtable data) {
+            ushort dataCount = 0;
+            var values = new ArrayList();
+            foreach (DictionaryEntry entry in data) {
+                dataCount += Encode(entry, out var output);
+                values.Add(output);
+            }
+
+            // empty
+            if (data.Count > 0)
+                dataCount += CrcSize; // if any data add size of crc to count
+
+            // too large for memory
+            if (dataCount > ((IMemoryInterface)this).Size - (Sentinel.Length - 1 + DataCountSize)) // lost capacity from not wrapping sentinel
+                return false;
+
+            var headerSize = Sentinel.Length + DataCountSize;
+            var encoded = new byte[headerSize + dataCount];
+            Array.Copy(Sentinel, 0, encoded, 0, Sentinel.Length);
+            var count = BitConverter.GetBytes(dataCount);
+            Array.Copy(count, 0, encoded, Sentinel.Length, count.Length);
+
+            var runningDataCount = headerSize;
+            foreach (var value in values) {
+                var bytes = (byte[])value;
+                Array.Copy(bytes, 0, encoded, runningDataCount, bytes.Length);
+                runningDataCount += bytes.Length;
+            }
+
+            if (runningDataCount <= headerSize)
+                return Write(encoded);
+
+            Crc.Reset();
+            var crc = BitConverter.GetBytes(Crc.ComputeHash(encoded, headerSize, encoded.Length - (headerSize + CrcSize)));
+            Array.Copy(crc, 0, encoded, encoded.Length - CrcSize, crc.Length);
+
+            return ((IMemoryInterface)this).Size >= encoded.Length && Write(encoded);
+        }
+
+        /// <summary> Get entire memory area </summary>
+        /// <remarks> For debugging </remarks>
+        /// <returns> Entire memory area</returns>
+        void IMemoryInterface.Dump() {
+            var sb = Dump();
+
+            var block = new byte[_secureStorageController.BlockSize];
+            for (uint i = 0; i < _blockCount; i++) {
+                _secureStorageController.Read(i, block);
+                sb.Append($"{i,0x03:x2}| ");
+                for (var @byte = 0; @byte < 32; @byte++)
+                    sb.Append($"{block[@byte],0x03:x2} ");
+                Debug.WriteLine(sb.ToString());
+                sb.Clear();
+            }
+
+            Debug.WriteLine(sb.ToString());
+        }
+
+        #endregion Implementation of IMemoryInterface
+
+        ///  <summary>
+        ///  Return only data from full data frame
+        ///  </summary>
+        /// <remarks> Points to frame start </remarks>
+        ///  <param name="index"> Index of start of data frame in overall memory map</param>
+        ///  <param name="data"></param>
+        ///  <returns> True if memory is read successfully </returns>
+        private bool Read(int index, out byte[] data) {
+            var blockIndex = GetBlockIndex(index);
+            var byteIndex = GetByteIndex(index);
+
+            data = new byte[0];
+
+            // move index to count, get count
+            //byteIndex += Sentinel.Length;
+            if ((byteIndex += Sentinel.Length) >= _secureStorageController.BlockSize) {
+                ++blockIndex;
+                byteIndex = 0;
+            }
+
+            var read = new byte[_secureStorageController.BlockSize];
+            _secureStorageController.Read((uint)blockIndex, read);
+
+            // checking this here as any theoretical corruption in count can be recovered by redundancy
+            // data is larger than can fit into memory
+            var dataCount = BitConverter.ToUInt16(read, byteIndex);
+            if (dataCount > _secureStorageController.TotalSize - Sentinel.Length - DataCountSize)
+                return false;
+
+            // create result array
+            var buffer = new byte[dataCount];
+
+            // move index to data
+            //byteIndex += DataCountSize;
+            if ((byteIndex += DataCountSize) >= _secureStorageController.BlockSize) {
+                ++blockIndex;
+                byteIndex = 0;
+            }
+
+            // gather data
+            var remainingCount = (int)dataCount;
+            var destinationIndex = 0;
+            while (remainingCount > 0) {
+                _secureStorageController.Read((uint)blockIndex, read); // ToDo check this?
+                var segmentLength = (int)(_secureStorageController.BlockSize - byteIndex);
+                var length = remainingCount < segmentLength ? remainingCount : segmentLength;
+                Array.Copy(read, byteIndex, buffer, destinationIndex, length);
+                remainingCount -= length;
+                destinationIndex += length;
+                ++blockIndex;
+                byteIndex = 0;
+            }
+
+            if (dataCount > 0) {
+                var dataSize = buffer.Length - CrcSize;
+                data = new byte[dataSize];
+                Array.Copy(buffer, 0, data, 0, data.Length);
+
+                Crc.Reset();
+                return Crc.ComputeHash(buffer, 0, dataSize) == BitConverter.ToUInt16(buffer, dataSize);
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Write entire 1 full data frame (Sentinel to CRC) to memory, while maximizing wear leveling.<para />
+        /// Api limits writing to each block only once until erased, therefore all writes start at block index 0
+        /// </summary>
+        /// <param name="data"> Full data frame (Sentinel to CRC) </param>
+        /// <returns> True if data was verified to be written at least once </returns>
+        /// <exception cref="InvalidOperationException"> Thrown when a block of memory cant be read. </exception>
+        /// <remarks> Memory read in order to find end of data </remarks>
+        private bool Write(byte[] data) {
+            if (data == null) throw new ArgumentNullException(nameof(data));
+            var index = -1;
+
+            // seek data end
+            for (var blockIndex = (int)(_blockCount - 1); blockIndex >= 0; blockIndex--) // 255 -> 0
+            {
+                var read = new byte[_secureStorageController.BlockSize];
+
+                // bad block
+                if (_secureStorageController.Read((uint)blockIndex, read) != _secureStorageController.BlockSize)
+                    throw new InvalidOperationException($"{nameof(Write)} platform read failed"); // ToDo? retry? throw? move on?
+
+                var empty = true;
+                for (var byteIndex = (int)_secureStorageController.BlockSize - 1; byteIndex >= 0; byteIndex--) // 31 -> 0
+                {
+                    if (read[byteIndex] != 0xff) {
+                        index = (int)(++blockIndex * _secureStorageController.BlockSize); // secure storage blocks can only be written to once before requiring to be erased so go to next block
+                        empty = false;
+                        break;
+                    }
+                }
+
+                if (!empty)
+                    break;
+            }
+
+            // uninitialized
+            if (index < 0)
+                index = 0;
+
+            // full, will overflow
+            var full = index >= _secureStorageController.TotalSize;
+            var free = (int)_secureStorageController.TotalSize - index;
+            var needed = data.Length;
+            if (full || needed > free) {
+                Erase();
+                index = 0;
+            }
+
+            // write and validate
+            return CoreWrite(data, index, out var wrote) && Read(index, out _);
+        }
+
+        /// <summary>  Write entire 1 full or partial block to memory  </summary>
+        ///<remarks> Expects 1 full frame (Sentinel+Count+Data+Crc) </remarks>
+        /// <param name="data"> Full or partial block of memory to write</param>
+        /// <param name="index"> Start index </param>
+        /// <param name="count"> Bytes written </param>
+        /// <returns> True if resulting <see cref="count"/> = <see cref="data"/> length </returns>
+        private bool CoreWrite(byte[] data, int index, out int count) {
+            if (data == null) throw new ArgumentNullException(nameof(data));
+            var writeBuffer = new byte[_secureStorageController.BlockSize];
+            var remainingLength = data.Length;
+            count = 0;
+
+            while (remainingLength > 0) {
+                var blockIndex = GetBlockIndex(index);
+                var byteIndex = GetByteIndex(index);
+                var remainingBlockLength = (int)(_secureStorageController.BlockSize - byteIndex);
+                var writeLength = remainingLength < remainingBlockLength ? remainingLength : remainingBlockLength;
+
+                // empty, set, write
+                for (var i = 0; i < _secureStorageController.BlockSize; i++)
+                    writeBuffer[i] = byte.MaxValue;
+
+                Array.Copy(data, count, writeBuffer, byteIndex, writeLength);
+
+                if (_secureStorageController.Write((uint)blockIndex, writeBuffer) != _secureStorageController.BlockSize)
+                    return false; // write failed ToDo anything? go to next byte? block? throw? log?
+
+                // update indices
+                index += writeLength;
+                count += writeLength;
+                remainingLength -= writeLength;
+            }
+
+            return data.Length == count;
+        }
+
+        /// <summary> Erase Entire memory area if not already blank </summary>
+        private void Erase() {
+            if (!IsAllBlank())
+                _secureStorageController.Erase();
+        }
+
+        /// <summary>
+        /// Check entire memory area is blank (erased)
+        /// </summary>
+        /// <returns></returns>
+        private bool IsAllBlank() {
+            for (uint block = 0; block < _blockCount; block++)
+                if (!_secureStorageController.IsBlank(block))
+                    return false;
+
+            return true;
+        }
+
+        private int GetBlockIndex(int index) => (int)(index / _secureStorageController.BlockSize);
+
+        private int GetByteIndex(int index) => (int)(index % _secureStorageController.BlockSize);
+    }
+}

--- a/MemoryManager/GHIElectronics.TinyCLR.Drivers.MemoryManager/packages.config
+++ b/MemoryManager/GHIElectronics.TinyCLR.Drivers.MemoryManager/packages.config
@@ -1,9 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="GHIElectronics.TinyCLR.Core" version="2.1.0" targetFramework="net452" />
-  <package id="GHIElectronics.TinyCLR.Cryptography" version="2.1.0" targetFramework="net452" />
-  <package id="GHIElectronics.TinyCLR.Devices.Gpio" version="2.1.0" targetFramework="net452" />
-  <package id="GHIElectronics.TinyCLR.Devices.Rtc" version="2.1.0" targetFramework="net452" />
-  <package id="GHIElectronics.TinyCLR.Devices.SecureStorage" version="2.1.0" targetFramework="net452" />
-  <package id="GHIElectronics.TinyCLR.Native" version="2.1.0" targetFramework="net452" />
 </packages>

--- a/MemoryManager/GHIElectronics.TinyCLR.Drivers.MemoryManager/packages.config
+++ b/MemoryManager/GHIElectronics.TinyCLR.Drivers.MemoryManager/packages.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="GHIElectronics.TinyCLR.Core" version="2.1.0" targetFramework="net452" />
+  <package id="GHIElectronics.TinyCLR.Cryptography" version="2.1.0" targetFramework="net452" />
+  <package id="GHIElectronics.TinyCLR.Devices.Gpio" version="2.1.0" targetFramework="net452" />
+  <package id="GHIElectronics.TinyCLR.Devices.Rtc" version="2.1.0" targetFramework="net452" />
+  <package id="GHIElectronics.TinyCLR.Devices.SecureStorage" version="2.1.0" targetFramework="net452" />
+  <package id="GHIElectronics.TinyCLR.Native" version="2.1.0" targetFramework="net452" />
+</packages>

--- a/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Core/ConfigurationBit.cs
+++ b/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Core/ConfigurationBit.cs
@@ -1,0 +1,39 @@
+namespace GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.Core
+{
+    internal enum ConfigurationBit
+    {
+        /// bit 0 INTCC: Interrupt Clearing Control
+        ///		1 = Reading INTCAP register clears the interrupt
+        ///		0 = Reading GPIO register clears the interrupt
+        IntCC,
+
+        /// bit 1 INTPOL: Sets the polarity of the INT output pin.
+        ///		1 =  Active-high.
+        ///		0 =  Active-low.
+        IntPol,
+
+        /// bit 2 ODR: Configures the INT pin as an open-drain output.
+        ///		1 = Open-drain output (overrides the INTPOL bit).
+        ///		0 = Active driver output (INTPOL bit sets the polarity).
+        ODr,
+
+        /// bit 3 Unimplemented: Reads as 0
+
+        /// bit 4 Unimplemented: Reads as 0
+
+        /// bit 5 SEQOP: Sequential Operation mode bit.
+        ///		1 = Sequential operation disabled, address pointer does not increment.
+        ///		0 = Sequential operation enabled, address pointer increments.
+        SeqOp = 5,
+
+        /// bit 6 MIRROR: INT pins mirror bit
+        ///		1 = The INT pins are internally connected in a wired OR configuration
+        ///		0 = The INT pins are not connected. INTA is associated with Port A and INTB is associated with Port B
+        Mirror,
+
+        /// bit 7 BANK: Controls how the registers are addressed (see Figure 1-4 and Figure 1-5)
+        ///	    1 = The registers associated with each port are separated into different banks
+        ///	    0 = The registers are in the same bank (addresses are sequential)
+        Bank
+    }
+}

--- a/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Core/ControlRegister.cs
+++ b/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Core/ControlRegister.cs
@@ -1,0 +1,99 @@
+namespace GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.Core
+{
+    internal enum ControlRegister : byte
+    {
+        /// <summary> I/O Direction </summary>
+        /// <remarks>
+        ///     Controls the direction of the data I/O. When a bit is set, the corresponding pin becomes an input.
+        ///		When a bit is clear, the corresponding pin becomes an output.
+        /// </remarks>
+        IoDir = 0x00,
+
+        /// <summary> Input Polarity </summary>
+        /// <remarks>
+        ///		Allows the user to configure the polarity on the corresponding GPIO port bits.
+        ///		If a bit is set, the corresponding GPIO register bit will reflect the inverted value on the pin.
+        /// </remarks>
+        // ReSharper disable once InconsistentNaming
+        IPol = 0x01,
+
+        /// <summary> Interrupt on change control </summary>
+        /// <remarks>
+        ///     Controls the interrupt-on-change feature for each pin. If a bit is set, the corresponding pin is enabled for interrupt-on-change.
+        ///		The DEFVAL and INTCON registers must also be configured if any pins are enabled for interrupt-on-change.
+        /// </remarks>
+        GpIntEn = 0x02,
+
+        /// <summary> Default compare for interrupt on change </summary>
+        /// <remarks>
+        ///     The default comparison value is configured in the DEFVAL register. If enabled (via GPINTEN and INTCON) to
+        ///     compare against the DEFVAL register, an opposite value on the associated pin will cause an interrupt to occur.
+        /// </remarks>
+        DefVal = 0x03,
+
+        /// <summary> Interrupt Control </summary>
+        /// <remarks>
+        ///     Controls how the associated pin value is compared for the interrupt-on-change feature.
+        ///		If a bit is set, the corresponding I/O pin is compared against the associated bit in the DEFVAL register.
+        ///		If a bit value is clear, the corresponding I/O pin is compared against the previous value.
+        /// </remarks>
+        IntCon = 0x04,
+
+        /// <summary> I/O Expander Configuration </summary>
+        /// <remarks>
+        /// bit 7 BANK: Controls how the registers are addressed (see Figure 1-4 and Figure 1-5)
+        ///	    1 = The registers associated with each port are separated into different banks
+        ///	    0 = The registers are in the same bank (addresses are sequential)
+        /// bit 6 MIRROR: INT pins mirror bit
+        ///		1 = The INT pins are internally connected in a wired OR configuration
+        ///		0 = The INT pins are not connected. INTA is associated with Port A and INTB is associated with Port B
+        /// bit 5 SEQOP: Sequential Operation mode bit.
+        ///		1 = Sequential operation disabled, address pointer does not increment.
+        ///		0 = Sequential operation enabled, address pointer increments.
+        /// bit 4 Unimplemented: Reads as 0
+        /// bit 3 Unimplemented: Reads as 0
+        /// bit 2 ODR: Configures the INT pin as an open-drain output.
+        ///		1 = Open-drain output (overrides the INTPOL bit).
+        ///		0 = Active driver output (INTPOL bit sets the polarity).
+        /// bit 1 INTPOL: Sets the polarity of the INT output pin.
+        ///		1 =  Active-high.
+        ///		0 =  Active-low.bit 0
+        /// INTCC: Interrupt Clearing Control
+        ///		1 = Reading INTCAP register clears the interrupt
+        ///		0 = Reading GPIO register clears the interrupt
+        /// </remarks>
+        IoCon = 0x05,
+
+        /// <summary> Pull Up resistor configuration register </summary>
+        /// <remarks>
+        ///     Controls the pull-up resistors for the port pins. If a bit is set and the corresponding pin is configured as an input,
+        ///		the corresponding port pin is internally pulled up with a 100 kΩ resistor.
+        /// </remarks>
+        GpPu = 0x06,
+
+        /// <summary> Interrupt Flag </summary>
+        /// <remarks>
+        ///     Reflects the interrupt condition on the port pins of any pin that is enabled for interrupts via the GPINTEN register
+        ///		A ‘set’ bit indicates that the associated pin caused the interrupt. This register is ‘read-only’. Writes to this register will be ignored.
+        /// </remarks>
+        IntF = 0x07,
+
+        /// <summary> Interrupt Capture </summary>
+        /// <remarks>
+        ///     Captures the GPIO port value at the time the interrupt occurred. The register is ‘read only’ and is updated only when an interrupt occurs.
+        ///		The register will remain unchanged until the interrupt is cleared via a read of INTCAP or GPIO.
+        /// </remarks>
+        IntCap = 0x08,
+
+        /// <summary> GPIO </summary>
+        /// <remarks> Reflects the value on the port. Reading from this register reads the port. Writing to this register modifies the Output Latch (OLAT) register. </remarks>
+        GpIo = 0x09,
+
+        /// <summary> Output Latch </summary>
+        /// <remarks>
+        ///		Provides access to the output latches A read from this register results in a read of the OLAT and not the port itself.
+        ///		A write to this register modifies the output latches that modifies the pins configured as outputs.
+        /// </remarks>
+        OLat = 0x0A
+    }
+}

--- a/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Core/Mcp23Core.cs
+++ b/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Core/Mcp23Core.cs
@@ -1,0 +1,93 @@
+using System;
+
+// ReSharper disable InconsistentNaming
+#pragma warning disable IDE1006 // Naming Styles
+
+
+namespace GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.Core
+{
+	internal abstract class Mcp23Core
+	{
+		private static RegisterMapping _registerMapping;
+
+		internal enum RegisterMapping
+		{
+			Paired,
+			Segregated
+		}
+
+		internal enum Port
+		{
+			A,
+			B
+		}
+
+		internal enum PinMode
+		{
+			Output,
+			Input
+		}
+
+		internal static void Reset() => _registerMapping = default;
+
+		internal bool ReadBit(ControlRegister register, Port port, byte bit) => this.ReadBitValue(register, port, bit) > 0;
+
+		internal byte ReadBitValue(ControlRegister register, Port port, byte bit) => (byte)(this.ReadRegister(register, port) & ResolveBitMask(bit));
+
+		internal byte ReadRegister(ControlRegister register, Port port) => this.ReadRegister(ResolveRegister(register, port));
+
+		// overload to avoid upstream parameter comparisons. slow?
+		internal void WriteBit(ControlRegister register, Port port, byte bit, Enum value) => this.WriteBit(register, port, bit, Convert.ToByte($"{value}") != default);
+
+		internal void WriteBit(ControlRegister register, Port port, byte bit, bool value)
+		{
+			var reg = ResolveRegister(register, port);
+			if (value)
+				this.WriteRegister(reg, (byte)(this.ReadRegister(reg) | ResolveBitMask(bit)));
+			else
+				this.WriteRegister(reg, (byte)(this.ReadRegister(reg) & ~ResolveBitMask(bit)));
+		}
+
+		internal void WriteRegister(ControlRegister register, Port port, byte value)
+		{
+			switch (register)
+			{
+				case ControlRegister.IntCap:
+				case ControlRegister.IntF:
+					throw new ArgumentException($"{register}", "is read-only");
+			}
+
+			this.WriteRegister(ResolveRegister(register, port), value);
+		}
+
+		internal void SetRegisterMapping(RegisterMapping mapping)
+		{
+			if (mapping != _registerMapping)
+			{
+				this.WriteBit(ControlRegister.IoCon, default, (byte)ConfigurationBit.Bank, mapping);
+				_registerMapping = mapping;
+			}
+		}
+
+		internal static Port ResolvePortAndBit(int pinNumber, out byte bit)
+		{
+			bit = (byte)(pinNumber % 8);
+			return (Port)(pinNumber / 8);
+		}
+
+		internal static int ResolvePin(Port port, byte bit) => (8 * (int)port) + bit;
+
+		private protected abstract byte ReadRegister(byte register);
+
+		private protected abstract void WriteRegister(byte register, byte value);
+
+		private static byte ResolveRegister(ControlRegister register, Port portName)
+		{
+			var reg = (byte)register;
+			var port = (byte)portName;
+			return (byte)(_registerMapping == RegisterMapping.Paired ? (reg * 2) + port : reg | (byte)(port << 4));
+		}
+
+		private static byte ResolveBitMask(byte bit) => (byte)(1 << (bit % 8));
+	}
+}

--- a/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Core/Mcp23I2cCore.cs
+++ b/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Core/Mcp23I2cCore.cs
@@ -1,0 +1,22 @@
+using System;
+
+using GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.Device;
+
+
+namespace GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.Core
+{
+    internal class Mcp23I2CCore : Mcp23Core
+    {
+        #region Overrides of Mcp23Core
+
+        internal Mcp23I2CCore(DeviceSettings deviceSettings)
+        {
+        }
+
+        private protected override byte ReadRegister(byte register) => throw new NotImplementedException();
+
+        private protected override void WriteRegister(byte register, byte value) => throw new NotImplementedException();
+
+        #endregion
+    }
+}

--- a/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Core/Mcp23SpiCore.cs
+++ b/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Core/Mcp23SpiCore.cs
@@ -1,0 +1,63 @@
+using System;
+
+using GHIElectronics.TinyCLR.Devices.Gpio;
+using GHIElectronics.TinyCLR.Devices.Spi;
+using GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.Device;
+
+// ReSharper disable InconsistentNaming
+#pragma warning disable IDE1006 // Naming Styles
+
+
+namespace GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.Core
+{
+    internal class Mcp23SpiCore : Mcp23Core
+    {
+        private const byte WriteOpcode = 0x40;
+        private const byte ReadOpcode = 0x41;
+        private readonly SpiDevice _spiDevice;
+        private readonly GpioPin _chipSelect;
+
+        /// <summary> Opcode, Start Register, value </summary>
+        private static readonly byte[] Tx32 = new byte[4];
+        private static readonly byte[] Tx24 = new byte[3];
+        private static readonly byte[] Rx32 = new byte[4];
+        private static readonly byte[] Rx24 = new byte[3];
+
+        internal Mcp23SpiCore(DeviceSettings deviceSettings)
+        {
+            var spiExpanderOptions = (SpiDeviceSettings)deviceSettings;
+
+            this._chipSelect = spiExpanderOptions.ChipSelect ?? throw new ArgumentNullException(nameof(spiExpanderOptions.ChipSelect), "This implementation manages its own chip Select line and cannot be null");
+            this._chipSelect.SetDriveMode(GpioPinDriveMode.Output);
+            this._chipSelect.Write(GpioPinValue.High);
+
+            var spiConnectionSettings = new SpiConnectionSettings { ClockFrequency = spiExpanderOptions.Frequency };
+            this._spiDevice = spiExpanderOptions.Controller.GetDevice(spiConnectionSettings);
+        }
+
+        #region Overrides of Mcp23Core
+
+        private protected override byte ReadRegister(byte register)
+        {
+            this._chipSelect?.Write(GpioPinValue.Low);
+            Tx24[0] = ReadOpcode;
+            Tx24[1] = register;
+            Tx24[2] = 0;
+            this._spiDevice.TransferFullDuplex(Tx24, Rx24);
+            this._chipSelect?.Write(GpioPinValue.High);
+            return Rx24[2];
+        }
+
+        private protected override void WriteRegister(byte register, byte value)
+        {
+            this._chipSelect?.Write(GpioPinValue.Low);
+            Tx24[0] = WriteOpcode;
+            Tx24[1] = register;
+            Tx24[2] = value;
+            this._spiDevice.Write(Tx24);
+            this._chipSelect?.Write(GpioPinValue.High);
+        }
+
+        #endregion
+    }
+}

--- a/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Device/DeviceSettings.cs
+++ b/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Device/DeviceSettings.cs
@@ -1,0 +1,57 @@
+using System;
+
+using GHIElectronics.TinyCLR.Devices.Gpio;
+using GHIElectronics.TinyCLR.Devices.I2c;
+using GHIElectronics.TinyCLR.Devices.Spi;
+
+using static GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.Mcp23Xxx;
+using static GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.Mcp23Xxx.Product;
+
+
+namespace GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.Device
+{
+    internal abstract class DeviceSettings
+    {
+        protected DeviceSettings(Product product)
+        {
+            this.ThisProduct = product;
+
+            this.PortCount = product switch
+            {
+                Mcp23X08 or Mcp23X09 => 1,
+                Mcp23X17 or Mcp23X18 => 2,
+                _ => throw new ArgumentOutOfRangeException()
+            };
+        }
+
+        internal int PortCount { get; }
+
+        internal Product ThisProduct { get; }
+    }
+
+    internal class SpiDeviceSettings : DeviceSettings
+    {
+        internal SpiDeviceSettings(Product product, GpioPin chipSelect, SpiController controller, int frequency = 1_000_000) : base(product)
+        {
+            this.ChipSelect = chipSelect;
+            this.Controller = controller;
+            this.Frequency = frequency;
+        }
+
+        internal SpiController Controller { get; }
+        internal GpioPin ChipSelect { get; }
+        internal int Frequency { get; }
+    }
+
+    internal class I2CDeviceSettings : DeviceSettings
+    {
+        internal I2CDeviceSettings(Product product, GpioPin address, I2cController controller, int frequency = 400_000) : base(product)
+        {
+
+        }
+
+        internal I2cController Controller { get; }
+        internal GpioPin ChipSelect { get; }
+        internal int Frequency { get; }
+    }
+}

--- a/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Device/Mcp23ActiveDriveProvider.cs
+++ b/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Device/Mcp23ActiveDriveProvider.cs
@@ -1,0 +1,10 @@
+using GHIElectronics.TinyCLR.Devices.Gpio;
+
+
+namespace GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.Device
+{
+    internal class Mcp23ActiveDriveProvider : Mcp23GpioProviderBase
+    {
+        internal Mcp23ActiveDriveProvider(DeviceSettings deviceSettings, GpioPin reset = null, GpioPin interruptPin = null) : base(deviceSettings, reset, interruptPin) { }
+    }
+}

--- a/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Device/Mcp23GpioProvider.cs
+++ b/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Device/Mcp23GpioProvider.cs
@@ -1,0 +1,82 @@
+using System;
+
+using GHIElectronics.TinyCLR.Devices.Gpio;
+using GHIElectronics.TinyCLR.Devices.Gpio.Provider;
+using GHIElectronics.TinyCLR.Devices.I2c;
+using GHIElectronics.TinyCLR.Devices.Spi;
+
+using static GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.Mcp23Xxx;
+using static GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.Mcp23Xxx.Product;
+
+// ReSharper disable InconsistentNaming
+#pragma warning disable IDE1006 // Naming Styles
+
+
+namespace GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.Device
+{
+	public class Mcp23GpioProvider : IGpioControllerProvider
+	{
+		private readonly IGpioControllerProvider _ioExtender;
+
+		public Mcp23GpioProvider(Product product, SpiController controller, GpioPin chipSelect, int frequency = 1_000_000, GpioPin reset = null, GpioPin interruptPin = null)
+		{
+			var connectionSettings = new SpiDeviceSettings(product, chipSelect, controller, frequency);
+			this._ioExtender = connectionSettings.ThisProduct switch
+			{
+				Mcp23X09 or Mcp23X18 => new Mcp23OpenDrainProvider(connectionSettings, reset, interruptPin),
+				Mcp23X08 or Mcp23X17 => new Mcp23ActiveDriveProvider(connectionSettings, reset, interruptPin),
+				_ => throw new ArgumentOutOfRangeException(nameof(connectionSettings.ThisProduct), "Device unsupported")
+			};
+		}
+
+		public Mcp23GpioProvider(Product product, I2cController controller, GpioPin address = null, int frequency = 400_000, GpioPin reset = null, GpioPin interruptPin = null)
+		{
+			var connectionSettings = new I2CDeviceSettings(product, address, controller, frequency);
+			this._ioExtender = connectionSettings.ThisProduct switch
+			{
+				Mcp23X09 or Mcp23X18 => new Mcp23OpenDrainProvider(connectionSettings, reset, interruptPin),
+				Mcp23X08 or Mcp23X17 => new Mcp23ActiveDriveProvider(connectionSettings, reset, interruptPin),
+				_ => throw new ArgumentOutOfRangeException(nameof(connectionSettings.ThisProduct), "Device unsupported")
+			};
+		}
+
+		#region Implementation of IGpioControllerProvider
+
+		public int PinCount => this._ioExtender.PinCount;
+
+		public void OpenPin(int pin) => this._ioExtender.OpenPin(pin);
+
+		public void ClosePin(int pin) => this._ioExtender.ClosePin(pin);
+
+		public void SetPinChangedHandler(int pin, GpioPinEdge edge, GpioPinValueChangedEventHandler value) => this._ioExtender.SetPinChangedHandler(pin, edge, value);
+
+		public void ClearPinChangedHandler(int pin) => this._ioExtender.ClearPinChangedHandler(pin);
+
+		public TimeSpan GetDebounceTimeout(int pin) => this._ioExtender.GetDebounceTimeout(pin);
+
+		public void SetDebounceTimeout(int pin, TimeSpan value) => this._ioExtender.SetDebounceTimeout(pin, value);
+
+		public bool IsDriveModeSupported(int pin, GpioPinDriveMode mode) => this._ioExtender.IsDriveModeSupported(pin, mode);
+
+		public GpioPinDriveMode GetDriveMode(int pin) => this._ioExtender.GetDriveMode(pin);
+
+		public void SetDriveMode(int pin, GpioPinDriveMode mode) => this._ioExtender.SetDriveMode(pin, mode);
+
+		public GpioPinValue Read(int pin) => this._ioExtender.Read(pin);
+
+		public void Write(int pin, GpioPinValue value) => this._ioExtender.Write(pin, value);
+
+		public void TransferFeature(int pinSource, int pinDestination, uint mode, uint type, uint direction, uint speed, uint alternate) => throw new NotImplementedException();
+
+		#endregion
+
+		#region Implementation of IDisposable
+
+		public void Dispose()
+		{
+			throw new NotImplementedException();
+		}
+
+		#endregion
+	}
+}

--- a/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Device/Mcp23GpioProvider.cs
+++ b/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Device/Mcp23GpioProvider.cs
@@ -72,6 +72,7 @@ namespace GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.Device
 
 		#region Implementation of IDisposable
 
+		// ToDo implement Dispose
 		public void Dispose()
 		{
 			throw new NotImplementedException();

--- a/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Device/Mcp23GpioProviderBase.cs
+++ b/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Device/Mcp23GpioProviderBase.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Collections;
+
+using GHIElectronics.TinyCLR.Devices.Gpio;
+using GHIElectronics.TinyCLR.Devices.Gpio.Provider;
+using GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.Core;
+using GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.Interrupt;
+using GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.Io;
+
+// ReSharper disable InconsistentNaming
+#pragma warning disable IDE1006 // Naming Styles
+
+
+namespace GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.Device
+{
+	internal abstract class Mcp23GpioProviderBase : IGpioControllerProvider
+	{
+		private readonly int _portCount;
+		private readonly Mcp23Interrupt _interrupt;
+		private readonly IDictionary _pinMap;
+
+		protected Mcp23GpioProviderBase(DeviceSettings deviceSettings, GpioPin reset = null, GpioPin interruptPin = null)
+		{
+			this._portCount = deviceSettings.PortCount;
+			Mcp23Core mcp23SCore = deviceSettings is SpiDeviceSettings ? new Mcp23SpiCore(deviceSettings) : new Mcp23I2CCore(deviceSettings);
+
+			if (reset is not null)
+			{
+				reset.SetDriveMode(GpioPinDriveMode.Output);
+				reset.Write(GpioPinValue.High);
+				reset.Write(GpioPinValue.Low);
+				reset.Write(GpioPinValue.High);
+
+				Mcp23Core.Reset();
+			}
+
+			// implementation details
+			mcp23SCore.SetRegisterMapping(default); // set register mapping to BANK = 0, redundant
+			mcp23SCore.WriteBit(ControlRegister.IoCon, default, (byte)ConfigurationBit.SeqOp, true); // Disable Sequential Address Mode
+
+			this.Io = new Mcp23Io(mcp23SCore, this._portCount);
+			this._pinMap = new Hashtable();
+
+			if (interruptPin is not null)
+			{
+				this._interrupt = new Mcp23Interrupt(mcp23SCore, this._portCount, interruptPin);
+				this._interrupt.PinChange += (_, args) =>
+				{
+					var handler = default(GpioPinValueChangedEventHandler);
+
+					var pin = Mcp23Core.ResolvePin(args.Port, args.Bit);
+					lock (this._pinMap)
+						if (this._pinMap.Contains(pin) && this._pinMap[pin] is GpioPinValueChangedEventHandler eventHandler)
+							handler = eventHandler;
+
+					handler?.Invoke(null, new GpioPinValueChangedEventArgs(args.Value == GpioPinValue.High ? GpioPinEdge.RisingEdge : GpioPinEdge.FallingEdge, args.Timestamp));
+				};
+			}
+		}
+
+		internal Mcp23Io Io { get; }
+
+		#region Implementation of IGpioExtender
+
+		public int PinCount => this._portCount * 8;
+
+		public void OpenPin(int pin)
+		{
+			if (pin < default(int) || pin >= this.PinCount)
+				throw new ArgumentOutOfRangeException(nameof(pin), "Pin is out of range and cannot be opened.");
+
+			lock (this._pinMap)
+				this._pinMap.Add(pin, null); // also throw if pin already added, apparently what framework wants.
+		}
+
+		public void ClosePin(int pin)
+		{
+			lock (this._pinMap)
+				if (this._pinMap.Contains(pin))
+					this._pinMap.Remove(pin);
+		}
+
+		public void SetPinChangedHandler(int pin, GpioPinEdge edge, GpioPinValueChangedEventHandler value)
+		{
+			if (this._interrupt is not null)
+			{
+				lock (this._pinMap)
+					this._pinMap[pin] = value;
+
+				var port = Mcp23Core.ResolvePortAndBit(pin, out var bit);
+				this._interrupt.SetPinInterruptMode(port, bit, edge);
+				this._interrupt.EnablePinChangeInterrupt(port, bit, true);
+			}
+		}
+
+		public void ClearPinChangedHandler(int pin)
+		{
+			if (this._interrupt is not null)
+			{
+				var port = Mcp23Core.ResolvePortAndBit(pin, out var bit);
+				this._interrupt.EnablePinChangeInterrupt(port, bit, false);
+
+				lock (this._pinMap)
+					this._pinMap[pin] = default(GpioPinValueChangedEventHandler);
+			}
+		}
+
+		public TimeSpan GetDebounceTimeout(int pin) => this._interrupt != null ? this._interrupt.GetDebounceTimeout(Mcp23Core.ResolvePortAndBit(pin, out var bit), bit) : TimeSpan.FromMilliseconds(-1);
+
+		public void SetDebounceTimeout(int pin, TimeSpan timeSpan) => this._interrupt?.SetDebounceTimeout(Mcp23Core.ResolvePortAndBit(pin, out var bit), bit, timeSpan);
+
+		public virtual bool IsDriveModeSupported(int pin, GpioPinDriveMode mode) => mode is GpioPinDriveMode.InputPullUp or GpioPinDriveMode.Input or GpioPinDriveMode.Output;
+
+		public virtual GpioPinDriveMode GetDriveMode(int pin)
+		{
+			var port = Mcp23Core.ResolvePortAndBit(pin, out var bit);
+			var mode = this.Io.GetPinMode(port, bit);
+			return mode == Mcp23Core.PinMode.Output ? GpioPinDriveMode.Output : this.Io.IsPinPullUp(port, bit) ? GpioPinDriveMode.InputPullUp : GpioPinDriveMode.Input;
+		}
+
+		public virtual void SetDriveMode(int pin, GpioPinDriveMode mode)
+		{
+			var port = Mcp23Core.ResolvePortAndBit(pin, out var bit);
+			switch (mode)
+			{
+				case GpioPinDriveMode.Input:
+					this.Io.SetPinMode(port, bit, Mcp23Core.PinMode.Input);
+					this.Io.EnablePinPullUp(port, bit, false);
+					break;
+				case GpioPinDriveMode.Output:
+					this.Io.SetPinMode(port, bit, Mcp23Core.PinMode.Output);
+					this.Io.EnablePinPullUp(port, bit, true);
+					break;
+				case GpioPinDriveMode.InputPullUp:
+					this.Io.SetPinMode(port, bit, Mcp23Core.PinMode.Input);
+					this.Io.EnablePinPullUp(port, bit, true);
+					break;
+				default:
+					throw new ArgumentOutOfRangeException(nameof(mode), "gpio extender does not support this drive mode");
+			}
+		}
+
+		public GpioPinValue Read(int pin) => this.Io.ReadPin(Mcp23Core.ResolvePortAndBit(pin, out var bit), bit);
+
+		public void Write(int pin, GpioPinValue value) => this.Io.WritePin(Mcp23Core.ResolvePortAndBit(pin, out var bit), bit, value);
+
+		public void TransferFeature(int pinSource, int pinDestination, uint mode, uint type, uint direction, uint speed, uint alternate) => throw new NotImplementedException();
+
+		#endregion
+
+		#region Implementation of IDisposable
+
+		public void Dispose()
+		{
+			// ToDo implement IDisposable in each object, and call from here
+			// dispose of everything here
+		}
+
+		#endregion
+	}
+}

--- a/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Device/Mcp23OpenDrainProvider.cs
+++ b/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Device/Mcp23OpenDrainProvider.cs
@@ -6,8 +6,7 @@ namespace GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.Device
 {
 	internal class Mcp23OpenDrainProvider : Mcp23GpioProviderBase
 	{
-		internal Mcp23OpenDrainProvider(DeviceSettings deviceSettings, GpioPin reset = null, GpioPin interruptPin = null)
-			: base(deviceSettings, reset, interruptPin) { }
+		internal Mcp23OpenDrainProvider(DeviceSettings deviceSettings, GpioPin reset = null, GpioPin interruptPin = null) : base(deviceSettings, reset, interruptPin) { }
 
 		#region Overrides of Mcp23GpioProviderBase
 

--- a/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Device/Mcp23OpenDrainProvider.cs
+++ b/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Device/Mcp23OpenDrainProvider.cs
@@ -1,0 +1,43 @@
+using GHIElectronics.TinyCLR.Devices.Gpio;
+using GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.Core;
+
+
+namespace GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.Device
+{
+	internal class Mcp23OpenDrainProvider : Mcp23GpioProviderBase
+	{
+		internal Mcp23OpenDrainProvider(DeviceSettings deviceSettings, GpioPin reset = null, GpioPin interruptPin = null)
+			: base(deviceSettings, reset, interruptPin) { }
+
+		#region Overrides of Mcp23GpioProviderBase
+
+		public override bool IsDriveModeSupported(int pin, GpioPinDriveMode mode) => mode is GpioPinDriveMode.OutputOpenDrain || base.IsDriveModeSupported(pin, mode);
+
+		public override GpioPinDriveMode GetDriveMode(int pin)
+		{
+			var port = Mcp23Core.ResolvePortAndBit(pin, out var bit); // duplicate call in base branch, least expensive option
+
+			if (!this.Io.IsPinPullUp(port, bit))
+			{
+				if (this.Io.GetPinMode(port, bit) == Mcp23Core.PinMode.Output)
+					return GpioPinDriveMode.OutputOpenDrain;
+			}
+
+			return base.GetDriveMode(pin);
+		}
+
+		public override void SetDriveMode(int pin, GpioPinDriveMode mode)
+		{
+			if (mode == GpioPinDriveMode.OutputOpenDrain)
+			{
+				var port = Mcp23Core.ResolvePortAndBit(pin, out var bit);
+				this.Io.SetPinMode(port, bit, Mcp23Core.PinMode.Output);
+				this.Io.EnablePinPullUp(port, bit, false);
+			}
+			else
+				base.SetDriveMode(pin, mode);
+		}
+
+		#endregion
+	}
+}

--- a/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.csproj
+++ b/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.csproj
@@ -1,0 +1,80 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\packages\GHIElectronics.TinyCLR.Core.2.1.0\build\net452\GHIElectronics.TinyCLR.Core.props" Condition="Exists('..\..\..\packages\GHIElectronics.TinyCLR.Core.2.1.0\build\net452\GHIElectronics.TinyCLR.Core.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{4DAE42D1-9BE6-47A5-93C1-4347A06746D4}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx</RootNamespace>
+    <AssemblyName>GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{A1948822-69DD-4150-919B-F3F42EFB71CC};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <LangVersion>9</LangVersion>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Core\ConfigurationBit.cs" />
+    <Compile Include="Core\ControlRegister.cs" />
+    <Compile Include="Core\Mcp23Core.cs" />
+    <Compile Include="Core\Mcp23I2cCore.cs" />
+    <Compile Include="Core\Mcp23SpiCore.cs" />
+    <Compile Include="Device\DeviceSettings.cs" />
+    <Compile Include="Device\Mcp23ActiveDriveProvider.cs" />
+    <Compile Include="Device\Mcp23GpioProvider.cs" />
+    <Compile Include="Device\Mcp23GpioProviderBase.cs" />
+    <Compile Include="Device\Mcp23OpenDrainProvider.cs" />
+    <Compile Include="Interrupt\InterruptCore.cs" />
+    <Compile Include="Interrupt\InterruptEventArgs.cs" />
+    <Compile Include="Interrupt\Mcp23Interrupt.cs" />
+    <Compile Include="Io\IoCore.cs" />
+    <Compile Include="Io\Mcp23Io.cs" />
+    <Compile Include="Mcp23Xxx.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="GHIElectronics.TinyCLR.Devices.Gpio">
+      <HintPath>..\..\..\..\TinyCLR-Libraries\GHIElectronics.TinyCLR.Devices.Gpio\bin\Debug\GHIElectronics.TinyCLR.Devices.Gpio.dll</HintPath>
+    </Reference>
+    <Reference Include="GHIElectronics.TinyCLR.Devices.I2c">
+      <HintPath>..\..\..\..\TinyCLR-Libraries\GHIElectronics.TinyCLR.Devices.I2c\bin\Debug\GHIElectronics.TinyCLR.Devices.I2c.dll</HintPath>
+    </Reference>
+    <Reference Include="GHIElectronics.TinyCLR.Devices.Spi">
+      <HintPath>..\..\..\..\TinyCLR-Libraries\GHIElectronics.TinyCLR.Devices.Spi\bin\Debug\GHIElectronics.TinyCLR.Devices.Spi.dll</HintPath>
+    </Reference>
+    <Reference Include="GHIElectronics.TinyCLR.Native, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\GHIElectronics.TinyCLR.Native.2.1.0\lib\net452\GHIElectronics.TinyCLR.Native.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\..\packages\GHIElectronics.TinyCLR.Core.2.1.0\build\net452\GHIElectronics.TinyCLR.Core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\GHIElectronics.TinyCLR.Core.2.1.0\build\net452\GHIElectronics.TinyCLR.Core.props'))" />
+  </Target>
+</Project>

--- a/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.csproj
+++ b/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.csproj
@@ -54,9 +54,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <Reference Include="GHIElectronics.TinyCLR.Devices.Gpio">
       <HintPath>..\..\..\..\TinyCLR-Libraries\GHIElectronics.TinyCLR.Devices.Gpio\bin\Debug\GHIElectronics.TinyCLR.Devices.Gpio.dll</HintPath>
     </Reference>
@@ -66,9 +63,12 @@
     <Reference Include="GHIElectronics.TinyCLR.Devices.Spi">
       <HintPath>..\..\..\..\TinyCLR-Libraries\GHIElectronics.TinyCLR.Devices.Spi\bin\Debug\GHIElectronics.TinyCLR.Devices.Spi.dll</HintPath>
     </Reference>
-    <Reference Include="GHIElectronics.TinyCLR.Native, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\GHIElectronics.TinyCLR.Native.2.1.0\lib\net452\GHIElectronics.TinyCLR.Native.dll</HintPath>
+    <Reference Include="GHIElectronics.TinyCLR.Native">
+      <HintPath>..\..\..\..\TinyCLR-Libraries\GHIElectronics.TinyCLR.Native\bin\Debug\GHIElectronics.TinyCLR.Native.dll</HintPath>
     </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Interrupt/InterruptCore.cs
+++ b/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Interrupt/InterruptCore.cs
@@ -1,0 +1,176 @@
+using System;
+
+using System.Threading;
+using GHIElectronics.TinyCLR.Devices.Gpio;
+using GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.Core;
+
+// ReSharper disable InconsistentNaming
+#pragma warning disable IDE1006 // Naming Styles
+
+
+// ToDo test
+// To keep consistency between devices Gpio only is used.  Ass Active driver devices, x08/x17,
+// do not have the ability to clear the interrupts by reading Interrupt capture register even though that appears more reliable.
+namespace GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.Interrupt
+{
+	internal class InterruptCore
+	{
+		private static readonly TimeSpan InfiniteTimeSpan = TimeSpan.FromMilliseconds(-1);
+		private readonly Mcp23Core _mcp23Core;
+		private readonly Mcp23Core.Port _port;
+		private readonly Timer[] _dBounceTimer = new Timer[8];
+		private readonly TimeSpan[] _debounceTimeout = new TimeSpan[8];
+		private byte _intCap, _lastCap;
+		private InterruptEventHandler _pinChange;
+		// ToDo INTCC workaround
+		/// <summary>
+		/// work around for devices' funky single edge interrupt mode.
+		/// from spec: "Read GPIO or INTCAP (INT clears only if interrupt condition does not exist.)"
+		/// wtf. need to continuously poll until bit changes back to DEF then clear the flag?
+		/// no reason to use interrupt if need to poll.
+		/// see spec FIGURE 1-12:
+		/// </summary>
+		private GpioPinEdge _edge;// = GpioPinEdge.FallingEdge | GpioPinEdge.RisingEdge;
+
+		/// <summary>
+		/// Implements an 8 bit interrupt port
+		/// </summary>
+		/// <param name="mcp23Core"></param>
+		/// <param name="port"> extenders GPIO port </param>
+		internal InterruptCore(Mcp23Core mcp23Core, Mcp23Core.Port port)
+		{
+			this._mcp23Core = mcp23Core ?? throw new ArgumentNullException(nameof(mcp23Core), "cannot be null");
+			this._port = port;
+			// ToDo INTCC workaround
+			//_intCap = _lastCap = _mcp23Core.ReadRegister(ControlRegister.IntCap, _port); // clear int flags
+			this._intCap = this._lastCap = this._mcp23Core.ReadRegister(ControlRegister.GpIo, this._port); // clear int flags
+		}
+
+		internal event InterruptEventHandler PinChange
+		{
+			add
+			{
+				// clean but a hack to ensure only 1 subscribed event handler.
+				// Not too concerned missing an interrupt as this should be done once on initialization and only removed if all 8 pins closed?
+				this._pinChange -= value;
+				this._pinChange += value;
+			}
+			remove => this._pinChange -= value;
+		}
+
+		internal enum PinChangeCompareValue
+		{
+			Last,
+			Default
+		}
+
+		internal TimeSpan GetDebounceTimeout(byte pin) => this._debounceTimeout[pin];
+
+		internal void SetDebounceTimeout(byte pin, TimeSpan timeSpan) => this._debounceTimeout[pin] = timeSpan;
+
+		/// <summary>
+		/// Set pin interrupt trigger condition.
+		/// - trigger port interrupt on any change or when changing from a set default value
+		/// </summary>
+		/// <param name="pin">interrupt pin to set</param>
+		/// <param name="mode">interrupt compare mode, from last (any change) or from defaultValue value</param>
+		/// <param name="defaultValue">if mode is default this is the default value to compare against, and interrupt when different</param>
+		internal void SetPinInterruptMode(byte pin, PinChangeCompareValue mode, GpioPinValue defaultValue = default)
+		{
+			if (mode == PinChangeCompareValue.Default)
+				this._mcp23Core.WriteBit(ControlRegister.DefVal, this._port, pin, defaultValue);
+
+			this._mcp23Core.WriteBit(ControlRegister.IntCon, this._port, pin, mode);
+		}
+
+		/// /// <summary>
+		/// work around for devices' funky single edge interrupt mode.
+		/// from spec: "Read GPIO or INTCAP (INT clears only if interrupt condition does not exist.)"
+		/// wtf. need to continuously poll until bit changes back to DEF in order to clear the flag?
+		/// no reason to use interrupt if need to poll.
+		/// see spec FIGURE 1-12:
+		/// </summary>
+		/// <param name="pin">interrupt pin to set</param>
+		/// <param name="edge">interrupt edge</param>
+		internal void SetPinInterruptMode(byte pin, GpioPinEdge edge)
+		{
+			this._edge = edge;
+			this._mcp23Core.WriteBit(ControlRegister.IntCon, this._port, pin, PinChangeCompareValue.Last);
+		}
+
+		/// <summary>
+		/// Enable a pin interrupt
+		/// </summary>
+		/// <param name="pin">interrupt pin to enable or disable</param>
+		/// <param name="enable">enable</param>
+		internal void EnableInterruptOnPinChange(byte pin, bool enable)
+		{
+			// avoid reinitializing the interrupt, specifically clearing the flag.
+			// TinyCLR framework will force this call when setting the interrupt edge as well as subscribing to it
+			switch (this._mcp23Core.ReadBit(ControlRegister.GpIntEn, this._port, pin))
+			{
+				case false when enable:
+				{
+					this._dBounceTimer[pin] ??= new Timer(b =>
+					{
+						var bit = (byte)b;
+						var bitMask = (1 << bit);
+						var intCap = this._intCap & bitMask;
+						if ((intCap ^ (this._lastCap & bitMask)) > 0) // if bit changed
+						{
+							var bitValue = intCap > 0 ? GpioPinValue.High : GpioPinValue.Low;
+							this._lastCap = bitValue == GpioPinValue.High ? (byte)(this._lastCap | bitMask) : this._lastCap = (byte)(this._lastCap & ~bitMask);
+							// ToDo INTCC workaround
+							//_pinChange?.Invoke(this, new InterruptEventArgs(_port, bit, bitValue, DateTime.Now)); // work around
+
+							switch (this._edge)
+							{
+								case GpioPinEdge.RisingEdge when bitValue == GpioPinValue.High:
+								case GpioPinEdge.FallingEdge when bitValue == GpioPinValue.Low:
+								case GpioPinEdge.FallingEdge | GpioPinEdge.RisingEdge: // both rising & falling
+									this._pinChange?.Invoke(this, new InterruptEventArgs(this._port, bit, bitValue, DateTime.Now));
+									break;
+							}
+						}
+					}, pin, InfiniteTimeSpan, InfiniteTimeSpan);
+
+					// capture initial value of pin (without clearing its' or others' interrupt flags
+					// ToDo INTCC workaround
+					//var gpio = _mcp23Core.ReadRegister(ControlRegister.GpIo, _port) & (1 << pin);
+					var gpio = this._mcp23Core.ReadRegister(ControlRegister.IntCap, this._port) & (1 << pin);
+					this._intCap = (byte)(this._intCap | gpio);
+					this._lastCap = (byte)(this._lastCap | gpio);
+
+					this._mcp23Core.WriteBit(ControlRegister.GpIntEn, this._port, pin, true);
+					break;
+				}
+				case true when !enable:
+				{
+					if (this._dBounceTimer[pin] is not null)
+						this._dBounceTimer[pin].Change(InfiniteTimeSpan, InfiniteTimeSpan);
+
+					this._mcp23Core.WriteBit(ControlRegister.GpIntEn, this._port, pin, false);
+					break;
+				}
+			}
+		}
+
+		// Bug: has threw twice due to reading IntF = 0xFF even though only one interrupt bit was enabled. Impossible. Both times device was being handled, ESD error? probably not.
+		/// <summary>
+		/// Called from upon port change interrupt
+		/// </summary>
+		internal void OnInterruptInputPinValueChanged()
+		{
+			var intFlag = this._mcp23Core.ReadRegister(ControlRegister.IntF, this._port);
+			// ToDo INTCC workaround
+			//_intCap = _mcp23Core.ReadRegister(ControlRegister.IntCap, _port); // clear int flags
+			this._intCap = this._mcp23Core.ReadRegister(ControlRegister.GpIo, this._port); // clear int flags
+
+			for (var bit = 0; bit < 8; bit++)
+			{
+				if ((intFlag & (1 << bit)) > 0 && this._dBounceTimer[bit] is not null ) // if pin caused interrupt then reset its dBounce timer, and avoid above noted Bug
+					this._dBounceTimer[bit].Change(this._debounceTimeout[bit], InfiniteTimeSpan);
+			}
+		}
+	}
+}

--- a/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Interrupt/InterruptCore.cs
+++ b/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Interrupt/InterruptCore.cs
@@ -8,9 +8,9 @@ using GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.Core;
 #pragma warning disable IDE1006 // Naming Styles
 
 
-// ToDo test
-// To keep consistency between devices Gpio only is used.  Ass Active driver devices, x08/x17,
-// do not have the ability to clear the interrupts by reading Interrupt capture register even though that appears more reliable.
+// ToDo INTCC workaround
+// To keep consistency between devices Gpio only is used.  As Active driver devices, x08/x17 both do not have
+// the ability to clear the interrupts by reading Interrupt capture register even though that appears more reliable.
 namespace GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.Interrupt
 {
 	internal class InterruptCore
@@ -155,7 +155,8 @@ namespace GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.Interrupt
 			}
 		}
 
-		// Bug: has threw twice due to reading IntF = 0xFF even though only one interrupt bit was enabled. Impossible. Both times device was being handled, ESD error? probably not.
+		// Bug: has threw twice due to reading IntF = 0xFF even though only one interrupt bit was enabled, which is not possible
+		// Both times device was being handled, ESD error? probably not.
 		/// <summary>
 		/// Called from upon port change interrupt
 		/// </summary>

--- a/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Interrupt/InterruptEventArgs.cs
+++ b/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Interrupt/InterruptEventArgs.cs
@@ -1,0 +1,26 @@
+using System;
+
+using GHIElectronics.TinyCLR.Devices.Gpio;
+using GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.Core;
+
+
+namespace GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.Interrupt
+{
+	internal delegate void InterruptEventHandler(object source, InterruptEventArgs e);
+
+	internal class InterruptEventArgs : EventArgs
+	{
+		internal InterruptEventArgs(Mcp23Core.Port port, byte bit, GpioPinValue value, DateTime timestamp)
+		{
+			this.Port = port;
+			this.Bit = bit;
+			this.Value = value;
+			this.Timestamp = timestamp;
+		}
+
+		internal Mcp23Core.Port Port { get; }
+		internal byte Bit { get; }
+		internal GpioPinValue Value { get; }
+		internal DateTime Timestamp { get; }
+	}
+}

--- a/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Interrupt/Mcp23Interrupt.cs
+++ b/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Interrupt/Mcp23Interrupt.cs
@@ -1,0 +1,86 @@
+using System;
+
+using GHIElectronics.TinyCLR.Devices.Gpio;
+using GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.Core;
+
+// ReSharper disable InconsistentNaming
+#pragma warning disable IDE1006 // Naming Styles
+
+
+namespace GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.Interrupt
+{
+	internal class Mcp23Interrupt
+	{
+		private readonly InterruptCore[] _interrupts;
+
+		internal Mcp23Interrupt(Mcp23Core mcp23Core, int portCount, GpioPin interruptInputPin, InterruptDriveMode interruptDriveMode = default, GpioPinValue interruptPolarity = default)
+		{
+			if (mcp23Core is null)
+				throw new ArgumentNullException(nameof(mcp23Core), $"{nameof(mcp23Core)} cannot be null");
+
+			if (interruptInputPin is null)
+				throw new ArgumentNullException(nameof(interruptInputPin), "Assigned interrupt pin must be initialize to utilize the IO expander interrupt function");
+
+			mcp23Core.WriteBit(ControlRegister.IoCon, default, (byte)ConfigurationBit.ODr, interruptDriveMode); // Set Interrupt Drive Mode
+			mcp23Core.WriteBit(ControlRegister.IoCon, default, (byte)ConfigurationBit.IntPol, interruptPolarity); // Set Active Interrupt Polarity
+			// ToDo INTCC workaround
+			//mcp23Core.WriteBit(ControlRegister.IoCon, default, (byte)ConfigurationBit.IntCC, InterruptClearRegister.IntCap); // Set Interrupt Flag Clear Control
+			mcp23Core.WriteBit(ControlRegister.IoCon, default, (byte)ConfigurationBit.IntCC, InterruptClearRegister.Gpio); // Set Interrupt Flag Clear Control
+			mcp23Core.WriteBit(ControlRegister.IoCon, default, (byte)ConfigurationBit.Mirror, true); // mirror interrupts allows use of either or interrupt pin
+
+			this._interrupts = new InterruptCore[portCount];
+			for (var p = 0; p < portCount; p++)
+				this._interrupts[p] = new InterruptCore(mcp23Core, (Mcp23Core.Port)p);
+
+			interruptInputPin.ValueChangedEdge = interruptPolarity == GpioPinValue.High ? GpioPinEdge.RisingEdge : GpioPinEdge.FallingEdge;
+			interruptInputPin.ValueChanged += (_, _) =>
+			{
+				foreach (var interrupt in this._interrupts)
+					interrupt.OnInterruptInputPinValueChanged();
+			};
+		}
+
+		internal event InterruptEventHandler PinChange
+		{
+			add
+			{
+				foreach (var interrupt in this._interrupts)
+				{
+					// clean but a hack to ensure only 1 subscribed event handler.
+					// Not too concerned missing an interrupt as this should be done once on initialization and only removed if all pins closed? ToDo add capability to remove handler after all pins released
+					interrupt.PinChange -= value;
+					interrupt.PinChange += value;
+				}
+			}
+			remove
+			{
+				foreach (var interrupt in this._interrupts)
+					interrupt.PinChange -= value;
+			}
+		}
+
+		internal enum InterruptDriveMode
+		{
+			ActiveDriver,
+			OpenDrain,
+		}
+
+		/// <summary>
+		/// To keep consistency between devices Gpio only is used.  Ass Active driver devices, x08/x17,
+		/// do not have the ability to clear the interrupts by reading Interrupt capture register even though that appears more reliable.
+		/// </summary>
+		private enum InterruptClearRegister
+		{
+			Gpio,
+			IntCap
+		}
+
+		internal TimeSpan GetDebounceTimeout(Mcp23Core.Port port, byte pin) => this._interrupts[(byte)port].GetDebounceTimeout(pin);
+
+		internal void SetDebounceTimeout(Mcp23Core.Port port, byte pin, TimeSpan value) => this._interrupts[(byte)port].SetDebounceTimeout(pin, value);
+
+		internal void SetPinInterruptMode(Mcp23Core.Port port, byte pin, GpioPinEdge edge) => this._interrupts[(byte)port].SetPinInterruptMode(pin, edge);
+
+		internal void EnablePinChangeInterrupt(Mcp23Core.Port port, byte pin, bool enable) => this._interrupts[(byte)port].EnableInterruptOnPinChange(pin, enable);
+	}
+}

--- a/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Interrupt/Mcp23Interrupt.cs
+++ b/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Interrupt/Mcp23Interrupt.cs
@@ -47,7 +47,7 @@ namespace GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.Interrupt
 				foreach (var interrupt in this._interrupts)
 				{
 					// clean but a hack to ensure only 1 subscribed event handler.
-					// Not too concerned missing an interrupt as this should be done once on initialization and only removed if all pins closed? ToDo add capability to remove handler after all pins released
+					// Not too concerned missing an interrupt as this should be done once on initialization and only removed if all pins closed? ToDo add capability to remove handler after all pins released?
 					interrupt.PinChange -= value;
 					interrupt.PinChange += value;
 				}

--- a/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Io/IoCore.cs
+++ b/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Io/IoCore.cs
@@ -21,7 +21,8 @@ namespace GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.Io
 		}
 
 		internal GpioPinValue ReadPin(byte pin) => this._mcp23Core.ReadBit(ControlRegister.GpIo, this._port, pin) ? GpioPinValue.High : GpioPinValue.Low;
-		internal void WritePin(byte pin, GpioPinValue value) => this._mcp23Core.WriteBit(ControlRegister.GpIo, this._port, pin, value);
+		//internal void WritePin(byte pin, GpioPinValue value) => this._mcp23Core.WriteBit(ControlRegister.GpIo, this._port, pin, value);
+		internal void WritePin(byte pin, GpioPinValue value) => this._mcp23Core.WriteBit(ControlRegister.OLat, this._port, pin, value);
 
 		internal void SetPinMode(byte pin, Mcp23Core.PinMode mode) => this._mcp23Core.WriteBit(ControlRegister.IoDir, this._port, pin, mode);
 		internal Mcp23Core.PinMode GetPinMode(byte pin) => (Mcp23Core.PinMode)this._mcp23Core.ReadBitValue(ControlRegister.IoDir, this._port, pin);

--- a/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Io/IoCore.cs
+++ b/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Io/IoCore.cs
@@ -1,0 +1,34 @@
+using System;
+
+using GHIElectronics.TinyCLR.Devices.Gpio;
+using GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.Core;
+
+// ReSharper disable InconsistentNaming
+#pragma warning disable IDE1006 // Naming Styles
+
+
+namespace GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.Io
+{
+	internal class IoCore
+	{
+		private readonly Mcp23Core _mcp23Core;
+		private readonly Mcp23Core.Port _port;
+
+		internal IoCore(Mcp23Core mcp23Core, Mcp23Core.Port port)
+		{
+			this._mcp23Core = mcp23Core ?? throw new ArgumentNullException(nameof(mcp23Core), "cannot be null");
+			this._port = port;
+		}
+
+		internal GpioPinValue ReadPin(byte pin) => this._mcp23Core.ReadBit(ControlRegister.GpIo, this._port, pin) ? GpioPinValue.High : GpioPinValue.Low;
+		internal void WritePin(byte pin, GpioPinValue value) => this._mcp23Core.WriteBit(ControlRegister.GpIo, this._port, pin, value);
+
+		internal void SetPinMode(byte pin, Mcp23Core.PinMode mode) => this._mcp23Core.WriteBit(ControlRegister.IoDir, this._port, pin, mode);
+		internal Mcp23Core.PinMode GetPinMode(byte pin) => (Mcp23Core.PinMode)this._mcp23Core.ReadBitValue(ControlRegister.IoDir, this._port, pin);
+
+		internal void InvertPinPolarity(byte pin, bool invert) => this._mcp23Core.WriteBit(ControlRegister.IPol, this._port, pin, invert);
+
+		internal void EnablePinPullUp(byte pin, bool enabled) => this._mcp23Core.WriteBit(ControlRegister.GpPu, this._port, pin, enabled);
+		internal bool IsPinPullUp(byte pin) => this._mcp23Core.ReadBit(ControlRegister.GpPu, this._port, pin);
+	}
+}

--- a/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Io/Mcp23Io.cs
+++ b/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Io/Mcp23Io.cs
@@ -1,0 +1,39 @@
+using System;
+
+using GHIElectronics.TinyCLR.Devices.Gpio;
+using GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.Core;
+
+// ReSharper disable InconsistentNaming
+#pragma warning disable IDE1006 // Naming Styles
+
+
+namespace GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx.Io
+{
+	internal class Mcp23Io
+	{
+		private readonly IoCore[] _ios;
+
+		internal Mcp23Io(Mcp23Core mcp23Core, int portCount)
+		{
+			if (mcp23Core is null)
+				throw new ArgumentNullException(nameof(mcp23Core), $"{nameof(mcp23Core)} cannot be null");
+
+			this._ios = new IoCore[portCount];
+			for (var port = 0; port < portCount; port++)
+			{
+				this._ios[port] = new IoCore(mcp23Core, (Mcp23Core.Port)port);
+			}
+		}
+
+		internal GpioPinValue ReadPin(Mcp23Core.Port port, byte pin) => this._ios[(byte)port].ReadPin(pin) ;
+		internal void WritePin(Mcp23Core.Port port, byte pin, GpioPinValue value) => this._ios[(byte)port].WritePin(pin, value);
+
+		internal void SetPinMode(Mcp23Core.Port port, byte pin, Mcp23Core.PinMode mode) => this._ios[(byte)port].SetPinMode(pin, mode);
+		internal Mcp23Core.PinMode GetPinMode(Mcp23Core.Port port, byte pin) => this._ios[(byte)port].GetPinMode(pin);
+
+		internal void InvertPinPolarity(Mcp23Core.Port port, byte pin, bool invert) => this._ios[(byte)port].InvertPinPolarity(pin, invert);
+
+		internal void EnablePinPullUp(Mcp23Core.Port port, byte pin, bool enabled) => this._ios[(byte)port].EnablePinPullUp(pin, enabled);
+		internal bool IsPinPullUp(Mcp23Core.Port port, byte pin) => this._ios[(byte)port].IsPinPullUp(pin);
+	}
+}

--- a/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Mcp23Xxx.cs
+++ b/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Mcp23Xxx.cs
@@ -1,0 +1,34 @@
+namespace GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx
+{
+    public static class Mcp23Xxx
+    {
+        public static class ExternalGpioPin
+        {
+            public const string Id = "MicroChip.GpioExtender.Mcp23xxx.GpioController\\0";
+            public const int GpA0 = 0;
+            public const int GpA1 = 1;
+            public const int GpA2 = 2;
+            public const int GpA3 = 3;
+            public const int GpA4 = 4;
+            public const int GpA5 = 5;
+            public const int GpA6 = 6;
+            public const int GpA7 = 7;
+            public const int GpB0 = 8;
+            public const int GpB1 = 9;
+            public const int GpB2 = 10;
+            public const int GpB3 = 11;
+            public const int GpB4 = 12;
+            public const int GpB5 = 13;
+            public const int GpB6 = 14;
+            public const int GpB7 = 15;
+        }
+
+        public enum Product
+        {
+            Mcp23X08,
+            Mcp23X09,
+            Mcp23X17,
+            Mcp23X18,
+        }
+    }
+}

--- a/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Properties/AssemblyInfo.cs
+++ b/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx")]
+[assembly: AssemblyCopyright("Copyright ©  2021")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("4dae42d1-9be6-47a5-93c1-4347a06746d4")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/packages.config
+++ b/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="GHIElectronics.TinyCLR.Core" version="2.1.0" targetFramework="net452" />
+  <package id="GHIElectronics.TinyCLR.Native" version="2.1.0" targetFramework="net452" />
+</packages>

--- a/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/packages.config
+++ b/Microchip/Mcp23xxx/GHIElectronics.TinyCLR.Drivers.Microchip.Mcp23xxx/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="GHIElectronics.TinyCLR.Core" version="2.1.0" targetFramework="net452" />
-  <package id="GHIElectronics.TinyCLR.Native" version="2.1.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Library/Driver to support Microchip Mcp23xxx series Gpio expanders.
Implements IGpioControllerProvider providing expander as native TinyClr GpioPin Type
 (commit includes Mcp23S18 implementation as proof of concept)

see required edits and sample of use
https://github.com/ghi-electronics/TinyCLR-Libraries/commit/ae790ae3688791542ac3d8bb433fae3a2e8fc140
https://github.com/ghi-electronics/TinyCLR-Samples/commit/02f6f22bfd1942bf8a333bd6ba0ecb1ec04d3870