### PR TITLE
Add newline and escape sequence support for BasicGraphics.DrawTinyString

### DIFF
--- a/BasicGraphics/BasicGraphics.cs
+++ b/BasicGraphics/BasicGraphics.cs
@@ -157,12 +157,29 @@ namespace GHIElectronics.TinyCLR.Drivers.BasicGraphics {
         }
         public void DrawTinyString(string text, uint color, int x, int y) => this.DrawTinyString(text, color, x, y, false);
         public void DrawTinyString(string text, uint color, int x, int y, bool clear) {
-            for (var i = 0; i < text.Length; i++) {
-                this.DrawTinyCharacter(text[i], color, x, y, clear);
-                x += 6;
-                if (clear) {
+            var originalX = x;
+            for (var i = 0; i < text.Length; i++)
+            {
+                if (text[i] >= 32)
+                {
+                    this.DrawTinyCharacter(text[i], color, x, y, clear);
+                    x += 6;
+                }
+                else
+                {
+                    if (text[i] == '\n')
+                    {
+                        y += 6;
+                        x = originalX;
+                    }
+                    if (text[i] == '\r')
+                        x = originalX;
+                }
+                if (clear)
+                {
                     // clear the space between chars
-                    for (var s = 0; s < 5; s++) {
+                    for (var s = 0; s < 5; s++)
+                    {
                         this.SetPixel(x - 1, y + s, 0);
                     }
                 }


### PR DESCRIPTION
I decided to port over this bit of code from BasicGraphics.DrawString because it significantly reduces the amount of times the DrawTinyString method would need to be called if the required string is very long and does not fit on a single line. I have tested it on an SSD1306 128x64px display and it seems to work without issue. Spacing was adjusted as required on said display; I have no others to test it on.